### PR TITLE
JIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ There's something magical about demonstrating a powerful concept with ~250 lines
 * [Virtual DOM](./virtual-dom/)
 * [Relational DB](./relational-db/)
 * [Precedence climbing parser](./precedence-climbing/)
+* [JIT](./just-in-time/)
 
 ## Contributing
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
 <li><a href="./virtual-dom/">Virtual DOM</a></li>
 <li><a href="./relational-db/">Relational DB</a></li>
 <li><a href="./precedence-climbing/">Precedence climbing parser</a></li>
+<li><a href="./just-in-time/">JIT</a></li>
 </ul>
 <h2>Contributing</h2>
 <p>Want to add a new example, or help annotate an existing one? <a href="https://github.com/pdubroy/200andchange">Open a PR</a>.</p>

--- a/docs/just-in-time/index.html
+++ b/docs/just-in-time/index.html
@@ -182,7 +182,8 @@ in lieu of a more powerful assembler</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-8">&#x00a7;</a>
               </div>
-              <p><code>dd</code> defines a (little endian) dword</p>
+              <p><code>dd</code> defines a dword: 4 little-endian bytes.
+<code>dd(0x12345678)</code> =&gt; <code>db([0x78,0x56,0x23,0x12])</code></p>
 
             </div>
             
@@ -198,7 +199,8 @@ in lieu of a more powerful assembler</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-9">&#x00a7;</a>
               </div>
-              <p><code>dq</code> defines a (little endian) quadword</p>
+              <p><code>dq</code> defines a quadword: 8 bytes.
+<code>dq(0x12345678)</code> =&gt; <code>db([0x78,0x56,0x23,0x12,0x0,0x0,0x0,0x0])</code></p>
 
             </div>
             
@@ -237,27 +239,7 @@ opcode data which must be fixed up at load time</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">add</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])
-
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">sub</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])
-
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">mul</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xf7</span>,<span class="hljs-number">0xe9</span>,<span class="hljs-number">0x50</span>])
-
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">div</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xf7</span>,<span class="hljs-number">0xf9</span>,<span class="hljs-number">0x50</span>])
-
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">leq</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xff</span>,<span class="hljs-number">0xc1</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>])
-    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe2</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0x52</span>])
-
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">lt</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe2</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0x52</span>])
-
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">neg</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x31</span>,<span class="hljs-number">0xc0</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">add</span>(<span class="hljs-params">a</span>):</pre></div></div>
             
         </li>
         
@@ -268,18 +250,13 @@ opcode data which must be fixed up at load time</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-12">&#x00a7;</a>
               </div>
-              <p>to handle <code>^</code> we call back into python code</p>
+              <p><em>popq %rcx; popq %rax; addq %rcx,%rax; pushq %rax</em></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-meta">@CFUNCTYPE(<span class="hljs-params">c_long, c_long,c_long</span>)</span>
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">py_exp</span>(<span class="hljs-params">a,b</span>):
-    <span class="hljs-keyword">return</span> a**b <span class="hljs-keyword">if</span> <span class="hljs-number">0</span>&lt;=b <span class="hljs-keyword">else</span> <span class="hljs-number">0</span> <span class="hljs-comment"># not quite right</span>
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])
 
-<span class="hljs-keyword">def</span> <span class="hljs-title function_">exp</span>(<span class="hljs-params">a</span>):
-    a.db([<span class="hljs-number">0x5e</span>,<span class="hljs-number">0x5f</span>,<span class="hljs-number">0x53</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x89</span>,<span class="hljs-number">0xe3</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe3</span>,<span class="hljs-number">0x08</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xdc</span>])
-    a.db([<span class="hljs-number">0xe8</span>]); a.reloc(cast(py_exp,c_void_p).value)
-    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0xdc</span>,<span class="hljs-number">0x5b</span>,<span class="hljs-number">0x50</span>])</pre></div></div>
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">sub</span>(<span class="hljs-params">a</span>):</pre></div></div>
             
         </li>
         
@@ -290,13 +267,13 @@ opcode data which must be fixed up at load time</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-13">&#x00a7;</a>
               </div>
-              <p>for simplicity <code>lit</code>eral data is always coded as a quad immediate</p>
+              <p><em>popq %rcx; popq %rax; subq %rcx,%rax; pushq %rax</em></p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">lit</span>(<span class="hljs-params">a,v</span>):
-    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0xb8</span>]); a.dq(v)
-    a.db([<span class="hljs-number">0x50</span>])</pre></div></div>
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">mul</span>(<span class="hljs-params">a</span>):</pre></div></div>
             
         </li>
         
@@ -306,6 +283,199 @@ opcode data which must be fixed up at load time</p>
               
               <div class="sswrap ">
                 <a class="ss" href="#section-14">&#x00a7;</a>
+              </div>
+              <p><em>popq %rcx; popq %rax; imulq %rcx; pushq %rax</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xf7</span>,<span class="hljs-number">0xe9</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">div</span>(<span class="hljs-params">a</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-15">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-15">&#x00a7;</a>
+              </div>
+              <p><em>popq %rcx; popq %rax; cqto; idivq %rcx; pushq %rax</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xf7</span>,<span class="hljs-number">0xf9</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">leq</span>(<span class="hljs-params">a</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-16">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-16">&#x00a7;</a>
+              </div>
+              <p><em>popq %rcx; popq %rax; incq %rcx; subq %rcx,%rax; cqto</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xff</span>,<span class="hljs-number">0xc1</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-17">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-17">&#x00a7;</a>
+              </div>
+              <p><em>andq $1, %rdx; pushq %rdx</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe2</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0x52</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">lt</span>(<span class="hljs-params">a</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-18">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-18">&#x00a7;</a>
+              </div>
+              <p><em>popq %rcx; popq %rax; subq %rcx,%rax; cqto; andq $1, %rdx; pushq %rdx</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe2</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0x52</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">neg</span>(<span class="hljs-params">a</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-19">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-19">&#x00a7;</a>
+              </div>
+              <p><em>popq %rcx; xorq %rax,%rax; subq %rcx,%rax; pushq %rax</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x31</span>,<span class="hljs-number">0xc0</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-20">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-20">&#x00a7;</a>
+              </div>
+              <p>to handle <code>^</code> we call back into python code</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-meta">@CFUNCTYPE(<span class="hljs-params">c_long, c_long,c_long</span>)</span>
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">py_exp</span>(<span class="hljs-params">a,b</span>):
+    <span class="hljs-keyword">return</span> a**b <span class="hljs-keyword">if</span> <span class="hljs-number">0</span>&lt;=b <span class="hljs-keyword">else</span> <span class="hljs-number">0</span> <span class="hljs-comment"># not quite right</span>
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">exp</span>(<span class="hljs-params">a</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-21">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-21">&#x00a7;</a>
+              </div>
+              <p><em>popq %rsi; popq %rdi; pushq %rbx; movq %rsp,%rbx; andq $8,%rbx; subq %rbx,%rsp</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x5e</span>,<span class="hljs-number">0x5f</span>,<span class="hljs-number">0x53</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x89</span>,<span class="hljs-number">0xe3</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe3</span>,<span class="hljs-number">0x08</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xdc</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-22">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-22">&#x00a7;</a>
+              </div>
+              <p><em>callq</em> <code>py_exp</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0xe8</span>]); a.reloc(cast(py_exp,c_void_p).value)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-23">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-23">&#x00a7;</a>
+              </div>
+              <p><em>addq %rbx,%rsp; popq %rbx; pushq %rax</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0xdc</span>,<span class="hljs-number">0x5b</span>,<span class="hljs-number">0x50</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-24">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-24">&#x00a7;</a>
+              </div>
+              <p>for simplicity <code>lit</code>eral data is always coded as a quad immediate</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">lit</span>(<span class="hljs-params">a,v</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-25">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-25">&#x00a7;</a>
+              </div>
+              <p><em>movabsq</em> <code>v</code><em>,%rax; pushq %rax</em></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0xb8</span>]); a.dq(v);
+    a.db([<span class="hljs-number">0x50</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-26">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-26">&#x00a7;</a>
               </div>
               <p>given a concrete syntax tree, <code>codegen</code> assembles the threaded
 code blocks in order to calculate its value</p>
@@ -322,11 +492,11 @@ code blocks in order to calculate its value</p>
         </li>
         
         
-        <li id="section-15">
+        <li id="section-27">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-15">&#x00a7;</a>
+                <a class="ss" href="#section-27">&#x00a7;</a>
               </div>
               <p>allow ascii-syntax operations as well</p>
 
@@ -340,11 +510,11 @@ code blocks in order to calculate its value</p>
         </li>
         
         
-        <li id="section-16">
+        <li id="section-28">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-16">&#x00a7;</a>
+                <a class="ss" href="#section-28">&#x00a7;</a>
               </div>
               <p><code>gen</code> does a syntax-directed tree walk. Gen of
 <code>[&#39;+&#39;,1,[&#39;*&#39;,2,3]]</code> assembles the concatenation <code>&lt;1&gt; &lt;2&gt; &lt;3&gt; * +</code></p>
@@ -361,11 +531,11 @@ code blocks in order to calculate its value</p>
         </li>
         
         
-        <li id="section-17">
+        <li id="section-29">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-17">&#x00a7;</a>
+                <a class="ss" href="#section-29">&#x00a7;</a>
               </div>
               <p>we process the syntax tree in postorder</p>
 
@@ -386,11 +556,11 @@ code blocks in order to calculate its value</p>
         </li>
         
         
-        <li id="section-18">
+        <li id="section-30">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-18">&#x00a7;</a>
+                <a class="ss" href="#section-30">&#x00a7;</a>
               </div>
               <hr>
 
@@ -399,11 +569,11 @@ code blocks in order to calculate its value</p>
         </li>
         
         
-        <li id="section-19">
+        <li id="section-31">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-19">&#x00a7;</a>
+                <a class="ss" href="#section-31">&#x00a7;</a>
               </div>
               
             </div>
@@ -414,11 +584,11 @@ Thunk = CFUNCTYPE(c_long)</pre></div></div>
         </li>
         
         
-        <li id="section-20">
+        <li id="section-32">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-20">&#x00a7;</a>
+                <a class="ss" href="#section-32">&#x00a7;</a>
               </div>
               <p><code>JitPage</code> grubs around with <code>ctypes</code> to load and execute the assembled code.
 The address of our executable page is <code>adr</code> and it extends <code>len</code> bytes.</p>
@@ -435,11 +605,11 @@ The address of our executable page is <code>adr</code> and it extends <code>len<
         </li>
         
         
-        <li id="section-21">
+        <li id="section-33">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-21">&#x00a7;</a>
+                <a class="ss" href="#section-33">&#x00a7;</a>
               </div>
               <p>there <em>has</em> to be a better way to check for SYSV x86-64!?</p>
 
@@ -455,11 +625,11 @@ The address of our executable page is <code>adr</code> and it extends <code>len<
         </li>
         
         
-        <li id="section-22">
+        <li id="section-34">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-22">&#x00a7;</a>
+                <a class="ss" href="#section-34">&#x00a7;</a>
               </div>
               <p>establish some libc linkages</p>
 
@@ -476,11 +646,11 @@ The address of our executable page is <code>adr</code> and it extends <code>len<
         </li>
         
         
-        <li id="section-23">
+        <li id="section-35">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-23">&#x00a7;</a>
+                <a class="ss" href="#section-35">&#x00a7;</a>
               </div>
               <p>allocate RWX page</p>
 
@@ -493,11 +663,11 @@ The address of our executable page is <code>adr</code> and it extends <code>len<
         </li>
         
         
-        <li id="section-24">
+        <li id="section-36">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-24">&#x00a7;</a>
+                <a class="ss" href="#section-36">&#x00a7;</a>
               </div>
               <p><code>fixup</code> is called if necessary at load time to encode <code>rip</code>-relative
 offsets between our calls and their referents</p>
@@ -509,11 +679,11 @@ offsets between our calls and their referents</p>
         </li>
         
         
-        <li id="section-25">
+        <li id="section-37">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-25">&#x00a7;</a>
+                <a class="ss" href="#section-37">&#x00a7;</a>
               </div>
               <p>assumption: our page and ctypes’ thunks are within 32 bits</p>
 
@@ -527,11 +697,11 @@ offsets between our calls and their referents</p>
         </li>
         
         
-        <li id="section-26">
+        <li id="section-38">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-26">&#x00a7;</a>
+                <a class="ss" href="#section-38">&#x00a7;</a>
               </div>
               <p><code>load</code> copies assembled code into the RWX page,
 returning a function pointer to the start of the assembly.</p>
@@ -547,11 +717,11 @@ returning a function pointer to the start of the assembly.</p>
         </li>
         
         
-        <li id="section-27">
+        <li id="section-39">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-27">&#x00a7;</a>
+                <a class="ss" href="#section-39">&#x00a7;</a>
               </div>
               <p>fill with breakpoints</p>
 
@@ -562,11 +732,11 @@ returning a function pointer to the start of the assembly.</p>
         </li>
         
         
-        <li id="section-28">
+        <li id="section-40">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-28">&#x00a7;</a>
+                <a class="ss" href="#section-40">&#x00a7;</a>
               </div>
               <p>load in the opcodes</p>
 
@@ -577,11 +747,11 @@ returning a function pointer to the start of the assembly.</p>
         </li>
         
         
-        <li id="section-29">
+        <li id="section-41">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-29">&#x00a7;</a>
+                <a class="ss" href="#section-41">&#x00a7;</a>
               </div>
               <p>fix up relative references</p>
 
@@ -594,11 +764,11 @@ returning a function pointer to the start of the assembly.</p>
         </li>
         
         
-        <li id="section-30">
+        <li id="section-42">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-30">&#x00a7;</a>
+                <a class="ss" href="#section-42">&#x00a7;</a>
               </div>
               <p><code>eval</code> assembles code for a parsed expression, loads, and executes</p>
 
@@ -611,11 +781,11 @@ returning a function pointer to the start of the assembly.</p>
         </li>
         
         
-        <li id="section-31">
+        <li id="section-43">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-31">&#x00a7;</a>
+                <a class="ss" href="#section-43">&#x00a7;</a>
               </div>
               <hr>
 
@@ -624,11 +794,11 @@ returning a function pointer to the start of the assembly.</p>
         </li>
         
         
-        <li id="section-32">
+        <li id="section-44">
             <div class="annotation">
               
               <div class="sswrap ">
-                <a class="ss" href="#section-32">&#x00a7;</a>
+                <a class="ss" href="#section-44">&#x00a7;</a>
               </div>
               
             </div>

--- a/docs/just-in-time/index.html
+++ b/docs/just-in-time/index.html
@@ -1,0 +1,668 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>An x86-64 (Mac/Linux) JIT demo in Python</title>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <link rel="stylesheet" media="all" href="../docco.css" />
+</head>
+<body>
+  <div id="container">
+    <div id="background"></div>
+    
+      <ul id="jump_to">
+        <li>
+          <a class="large" href="javascript:void(0);">Jump To &hellip;</a>
+          <a class="small" href="javascript:void(0);">+</a>
+          <div id="jump_wrapper">
+          <div id="jump_page_wrapper">
+            <div id="jump_page">
+              
+                
+                <a class="source" href="index.html">
+                  ./just-in-time/index.py
+                </a>
+              
+                
+                <a class="source" href="../packrat-parsing/index.html">
+                  ./packrat-parsing/index.js
+                </a>
+              
+                
+                <a class="source" href="../precedence-climbing/index.html">
+                  ./precedence-climbing/index.py
+                </a>
+              
+                
+                <a class="source" href="../relational-db/index.html">
+                  ./relational-db/index.py
+                </a>
+              
+                
+                <a class="source" href="../virtual-dom/index.html">
+                  ./virtual-dom/index.js
+                </a>
+              
+            </div>
+          </div>
+        </li>
+      </ul>
+    
+    <ul class="sections">
+        
+        
+        
+        <li id="section-1">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-1">&#x00a7;</a>
+              </div>
+              <h1 id="an-x86-64-maclinux-jit-demo-in-python">An x86-64 (Mac/Linux) JIT demo in Python</h1>
+<p><strong>License:</strong> MIT
+<strong>Copyright:</strong> (c) 2025 Dave Long</p>
+<p>In order to execute expressions parsed by Maxwell Bernstein’s precedence
+climbing <a href="https://pdubroy.github.io/200andchange/precedence-climbing/">parser</a>, we use a rudimentary assembler to put together threaded
+opcode blocks in post-order, keeping our intermediates on the <code>rsp</code> stack.</p>
+<p>Obtaining an executable page and just-in-time loading the assembled code
+into it is accomplished via the help of <code>ctypes</code>, on SYSV ABI platforms.</p>
+<hr>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-2">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-2">&#x00a7;</a>
+              </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>
+<span class="hljs-keyword">from</span> ctypes      <span class="hljs-keyword">import</span> cast, CFUNCTYPE, POINTER, pythonapi
+<span class="hljs-keyword">from</span> ctypes      <span class="hljs-keyword">import</span> c_char, c_int, c_long, c_char_p, c_void_p, c_size_t
+<span class="hljs-keyword">from</span> dataclasses <span class="hljs-keyword">import</span> dataclass, field
+<span class="hljs-keyword">from</span> os          <span class="hljs-keyword">import</span> name
+<span class="hljs-keyword">from</span> platform    <span class="hljs-keyword">import</span> processor, machine
+<span class="hljs-keyword">from</span> sys         <span class="hljs-keyword">import</span> maxsize
+<span class="hljs-keyword">from</span> typing      <span class="hljs-keyword">import</span> <span class="hljs-type">List</span>, <span class="hljs-type">Tuple</span>
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">JitError</span>(<span class="hljs-title class_ inherited__">Exception</span>):
+    <span class="hljs-keyword">pass</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-3">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-3">&#x00a7;</a>
+              </div>
+              <hr>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-4">&#x00a7;</a>
+              </div>
+              
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-5">&#x00a7;</a>
+              </div>
+              <p><code>Asm</code> builds an assembled expression. Most opcodes are position-independent,
+and are kept in the <code>ops</code> array, but call offsets are <code>rip</code>-relative and
+hence vary at runtime, so we keep relocations in the <code>rels</code> array for them.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-meta">@dataclass</span>
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">Asm</span>:
+    ops: <span class="hljs-type">List</span>[<span class="hljs-built_in">int</span>]             = field(default_factory=<span class="hljs-built_in">list</span>)
+    rels: <span class="hljs-type">List</span>[<span class="hljs-type">Tuple</span>[<span class="hljs-built_in">int</span>,<span class="hljs-built_in">int</span>]] = field(default_factory=<span class="hljs-built_in">list</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-6">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-6">&#x00a7;</a>
+              </div>
+              <p><code>dot</code> returns the current offset relative to the start</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">dot</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-built_in">int</span>:
+        <span class="hljs-keyword">return</span> <span class="hljs-built_in">len</span>(self.ops)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-7">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-7">&#x00a7;</a>
+              </div>
+              <p><code>db</code> defines bytes, which we use to specify opcodes
+in lieu of a more powerful assembler</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">db</span>(<span class="hljs-params">self, v: <span class="hljs-type">List</span>[<span class="hljs-built_in">int</span>]</span>):
+        self.ops.extend(v)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-8">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-8">&#x00a7;</a>
+              </div>
+              <p><code>dd</code> defines a (little endian) dword</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">dd</span>(<span class="hljs-params">self, v: <span class="hljs-built_in">int</span></span>):
+        self.db([(v&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">4</span>)])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-9">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-9">&#x00a7;</a>
+              </div>
+              <p><code>dq</code> defines a (little endian) quadword</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">dq</span>(<span class="hljs-params">self, v: <span class="hljs-built_in">int</span></span>):
+        self.db([(v&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">8</span>)])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-10">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-10">&#x00a7;</a>
+              </div>
+              <p><code>reloc</code> defines a relocation entry specifying
+opcode data which must be fixed up at load time</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">reloc</span>(<span class="hljs-params">self, dst: <span class="hljs-built_in">int</span></span>):
+        self.rels.append((self.dot(), dst))
+        self.dd(<span class="hljs-number">0</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-11">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-11">&#x00a7;</a>
+              </div>
+              <p>Assemble 0-address threaded code blocks for the various operations.
+(See also some of <a href="http://squoze.net/NB/nbilib.s">dmr’s threaded code</a>)</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">add</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">sub</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">mul</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xf7</span>,<span class="hljs-number">0xe9</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">div</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xf7</span>,<span class="hljs-number">0xf9</span>,<span class="hljs-number">0x50</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">leq</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0xff</span>,<span class="hljs-number">0xc1</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>])
+    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe2</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0x52</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">lt</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x58</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x99</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe2</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0x52</span>])
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">neg</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x59</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x31</span>,<span class="hljs-number">0xc0</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xc8</span>,<span class="hljs-number">0x50</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-12">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-12">&#x00a7;</a>
+              </div>
+              <p>to handle <code>^</code> we call back into python code</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-meta">@CFUNCTYPE(<span class="hljs-params">c_long, c_long,c_long</span>)</span>
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">py_exp</span>(<span class="hljs-params">a,b</span>):
+    <span class="hljs-keyword">return</span> a**b <span class="hljs-keyword">if</span> <span class="hljs-number">0</span>&lt;=b <span class="hljs-keyword">else</span> <span class="hljs-number">0</span> <span class="hljs-comment"># not quite right</span>
+
+<span class="hljs-keyword">def</span> <span class="hljs-title function_">exp</span>(<span class="hljs-params">a</span>):
+    a.db([<span class="hljs-number">0x5e</span>,<span class="hljs-number">0x5f</span>,<span class="hljs-number">0x53</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x89</span>,<span class="hljs-number">0xe3</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x83</span>,<span class="hljs-number">0xe3</span>,<span class="hljs-number">0x08</span>,<span class="hljs-number">0x48</span>,<span class="hljs-number">0x29</span>,<span class="hljs-number">0xdc</span>])
+    a.db([<span class="hljs-number">0xe8</span>]); a.reloc(cast(py_exp,c_void_p).value)
+    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0x01</span>,<span class="hljs-number">0xdc</span>,<span class="hljs-number">0x5b</span>,<span class="hljs-number">0x50</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-13">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-13">&#x00a7;</a>
+              </div>
+              <p>for simplicity <code>lit</code>eral data is always coded as a quad immediate</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">lit</span>(<span class="hljs-params">a,v</span>):
+    a.db([<span class="hljs-number">0x48</span>,<span class="hljs-number">0xb8</span>]); a.dq(v)
+    a.db([<span class="hljs-number">0x50</span>])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-14">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-14">&#x00a7;</a>
+              </div>
+              <p>given a concrete syntax tree, <code>codegen</code> assembles the threaded
+code blocks in order to calculate its value</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">def</span> <span class="hljs-title function_">codegen</span>(<span class="hljs-params">a:Asm, cst</span>) -&gt; Asm:
+    gentab = {
+    (<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">2</span>): add, (<span class="hljs-string">&#x27;-&#x27;</span>,<span class="hljs-number">2</span>): sub,
+    (<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">2</span>): mul, (<span class="hljs-string">&#x27;/&#x27;</span>,<span class="hljs-number">2</span>): div,
+    (<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">2</span>): exp, (<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>): neg,
+    (<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">2</span>): leq, (<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">2</span>): lt,</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-15">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-15">&#x00a7;</a>
+              </div>
+              <p>allow ascii-syntax operations as well</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    (<span class="hljs-string">&#x27;add&#x27;</span>,<span class="hljs-number">2</span>): add, (<span class="hljs-string">&#x27;sub&#x27;</span>,<span class="hljs-number">2</span>): sub,
+    (<span class="hljs-string">&#x27;mul&#x27;</span>,<span class="hljs-number">2</span>): mul, (<span class="hljs-string">&#x27;div&#x27;</span>,<span class="hljs-number">2</span>): div,
+    (<span class="hljs-string">&#x27;exp&#x27;</span>,<span class="hljs-number">2</span>): exp,
+    }</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-16">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-16">&#x00a7;</a>
+              </div>
+              <p><code>gen</code> does a syntax-directed tree walk. Gen of
+<code>[&#39;+&#39;,1,[&#39;*&#39;,2,3]]</code> assembles the concatenation <code>&lt;1&gt; &lt;2&gt; &lt;3&gt; * +</code></p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">gen</span>(<span class="hljs-params">a:Asm, cst</span>):
+        <span class="hljs-keyword">if</span> <span class="hljs-built_in">isinstance</span>(cst,<span class="hljs-built_in">int</span>):
+            lit(a,cst)
+        <span class="hljs-keyword">elif</span> <span class="hljs-built_in">isinstance</span>(cst,<span class="hljs-built_in">list</span>):
+            key = (cst[<span class="hljs-number">0</span>],<span class="hljs-built_in">len</span>(cst)-<span class="hljs-number">1</span>)
+            <span class="hljs-keyword">if</span> key <span class="hljs-keyword">in</span> gentab:</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-17">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-17">&#x00a7;</a>
+              </div>
+              <p>we process the syntax tree in postorder</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>                <span class="hljs-keyword">for</span> arg <span class="hljs-keyword">in</span> cst[<span class="hljs-number">1</span>:]:
+                  gen(a,arg)
+                gentab[key](a)
+            <span class="hljs-keyword">else</span>:
+                <span class="hljs-keyword">raise</span> JitError(<span class="hljs-string">&quot;unimplemented func&quot;</span>)
+        <span class="hljs-keyword">else</span>:
+            <span class="hljs-keyword">raise</span> JitError(<span class="hljs-string">&quot;unimplemented literal&quot;</span>)
+ 
+    gen(a, cst)
+    a.db([<span class="hljs-number">0x58</span>,<span class="hljs-number">0xc3</span>])
+    <span class="hljs-keyword">return</span> a</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-18">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-18">&#x00a7;</a>
+              </div>
+              <hr>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-19">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-19">&#x00a7;</a>
+              </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>
+Thunk = CFUNCTYPE(c_long)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-20">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-20">&#x00a7;</a>
+              </div>
+              <p><code>JitPage</code> grubs around with <code>ctypes</code> to load and execute the assembled code.
+The address of our executable page is <code>adr</code> and it extends <code>len</code> bytes.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">class</span> <span class="hljs-title class_">JitPage</span>:
+    valid: <span class="hljs-built_in">bool</span>
+    adr: <span class="hljs-built_in">int</span>
+    <span class="hljs-built_in">len</span>: <span class="hljs-built_in">int</span>
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self</span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-21">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-21">&#x00a7;</a>
+              </div>
+              <p>there <em>has</em> to be a better way to check for SYSV x86-64!?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> name != <span class="hljs-string">&#x27;posix&#x27;</span> <span class="hljs-keyword">or</span> maxsize != <span class="hljs-number">2</span>**<span class="hljs-number">63</span>-<span class="hljs-number">1</span> <span class="hljs-keyword">or</span> (<span class="hljs-keyword">not</span>
+           <span class="hljs-built_in">any</span>(<span class="hljs-string">&quot;86&quot;</span> <span class="hljs-keyword">in</span> f <span class="hljs-keyword">for</span> f <span class="hljs-keyword">in</span> [processor(),machine()])):
+            self.<span class="hljs-built_in">len</span>   = <span class="hljs-number">0</span>
+            self.adr   = <span class="hljs-number">0</span>
+            self.valid = <span class="hljs-literal">False</span>
+        <span class="hljs-keyword">else</span>:</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-22">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-22">&#x00a7;</a>
+              </div>
+              <p>establish some libc linkages</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            mc  = pythonapi.memcpy
+            mc.argtypes = (c_void_p,c_char_p,c_size_t)
+            ms  = pythonapi.memset
+            ms.argtypes = (c_void_p,c_char,c_size_t)
+            mm  = pythonapi.mmap
+            mm.restype = c_void_p
+            mm.argtype = (c_void_p,c_size_t,c_int,c_int,c_int,c_size_t)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-23">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-23">&#x00a7;</a>
+              </div>
+              <p>allocate RWX page</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            self.<span class="hljs-built_in">len</span>   = pythonapi.getpagesize()
+            self.adr   = pythonapi.mmap(<span class="hljs-number">0</span>, self.<span class="hljs-built_in">len</span>, <span class="hljs-number">7</span>, <span class="hljs-number">0x1022</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">0</span>)
+            self.valid = <span class="hljs-literal">True</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-24">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-24">&#x00a7;</a>
+              </div>
+              <p><code>fixup</code> is called if necessary at load time to encode <code>rip</code>-relative
+offsets between our calls and their referents</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">fixup</span>(<span class="hljs-params">self, off:<span class="hljs-built_in">int</span>, dst:<span class="hljs-built_in">int</span></span>):</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-25">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-25">&#x00a7;</a>
+              </div>
+              <p>assumption: our page and ctypes’ thunks are within 32 bits</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        adr = self.adr+off
+        rel = dst - (adr+<span class="hljs-number">4</span>)
+        buf = cast(adr, POINTER(c_char*<span class="hljs-number">4</span>)).contents
+        buf[:] = [(rel&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">4</span>)]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-26">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-26">&#x00a7;</a>
+              </div>
+              <p><code>load</code> copies assembled code into the RWX page,
+returning a function pointer to the start of the assembly.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">load</span>(<span class="hljs-params">self, a:Asm</span>) -&gt; Thunk:
+        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> self.valid:
+            <span class="hljs-keyword">raise</span> JitError(<span class="hljs-string">&quot;couldn&#x27;t confirm posix x86-64&quot;</span>)
+        <span class="hljs-keyword">if</span> a.dot() &gt; self.<span class="hljs-built_in">len</span>:
+            <span class="hljs-keyword">raise</span> JitError(<span class="hljs-string">&quot;too complex&quot;</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-27">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-27">&#x00a7;</a>
+              </div>
+              <p>fill with breakpoints</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        pythonapi.memset(self.adr, <span class="hljs-number">0xcc</span>, self.<span class="hljs-built_in">len</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-28">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-28">&#x00a7;</a>
+              </div>
+              <p>load in the opcodes</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        pythonapi.memcpy(self.adr, <span class="hljs-built_in">bytes</span>(a.ops), a.dot())</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-29">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-29">&#x00a7;</a>
+              </div>
+              <p>fix up relative references</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">for</span> off,dst <span class="hljs-keyword">in</span> a.rels:
+            self.fixup(off,dst)
+        <span class="hljs-keyword">return</span> Thunk(self.adr)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-30">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-30">&#x00a7;</a>
+              </div>
+              <p><code>eval</code> assembles code for a parsed expression, loads, and executes</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">eval</span>(<span class="hljs-params">self, expr</span>) -&gt; <span class="hljs-built_in">int</span>:
+        thunk = self.load(codegen(Asm(), expr))
+        <span class="hljs-keyword">return</span> thunk()</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-31">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-31">&#x00a7;</a>
+              </div>
+              <hr>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-32">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-32">&#x00a7;</a>
+              </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>
+<span class="hljs-keyword">if</span> __name__ == <span class="hljs-string">&quot;__main__&quot;</span>:
+    j = JitPage()
+
+    tests = [
+    (<span class="hljs-number">0</span>,<span class="hljs-number">0</span>),
+    ([<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>],-<span class="hljs-number">1</span>),
+    ([<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">3</span>,[<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">2</span>]],-<span class="hljs-number">6</span>),
+    ([<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">3</span>,<span class="hljs-number">2</span>],<span class="hljs-number">9</span>),
+    ([<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">3</span>,<span class="hljs-number">2</span>]],<span class="hljs-number">10</span>),
+    ([<span class="hljs-string">&#x27;/&#x27;</span>,[<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;-&#x27;</span>,[<span class="hljs-string">&#x27;-&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">10</span>],[<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">6</span>,[<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>]]],[<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>]]],<span class="hljs-number">2</span>],<span class="hljs-number">3</span>),
+    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>]],<span class="hljs-number">1</span>),
+    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">4</span>],<span class="hljs-number">1</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">1</span>],<span class="hljs-number">4</span>]],<span class="hljs-number">1</span>),
+    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>]],<span class="hljs-number">4</span>),
+    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>]],<span class="hljs-number">4</span>),
+    ([<span class="hljs-string">&#x27;add&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;mul&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>]],<span class="hljs-number">7</span>),
+    ]
+
+    <span class="hljs-keyword">for</span> xpr,res <span class="hljs-keyword">in</span> tests:
+        <span class="hljs-built_in">print</span>(j.<span class="hljs-built_in">eval</span>(xpr) == res)
+ 
+    <span class="hljs-keyword">try</span>:
+        j.<span class="hljs-built_in">eval</span>(<span class="hljs-string">&quot;1+&quot;</span>*<span class="hljs-number">500</span>+<span class="hljs-string">&quot;1&quot;</span>)
+        <span class="hljs-keyword">raise</span> Exception
+    <span class="hljs-keyword">except</span> JitError:
+        <span class="hljs-built_in">print</span>(<span class="hljs-literal">True</span>)</pre></div></div>
+            
+        </li>
+        
+    </ul>
+  </div>
+</body>
+</html>

--- a/docs/just-in-time/index.html
+++ b/docs/just-in-time/index.html
@@ -803,32 +803,43 @@ returning a function pointer to the start of the assembly.</p>
               
             </div>
             
-            <div class="content"><div class='highlight'><pre>
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">import</span> unittest
+
+<span class="hljs-keyword">class</span> <span class="hljs-title class_">SmokeTests</span>(unittest.TestCase):
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">setUp</span>(<span class="hljs-params">self</span>):
+        self.j = JitPage()
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_expressions</span>(<span class="hljs-params">self</span>):
+        tests = [
+        (<span class="hljs-number">0</span>,<span class="hljs-number">0</span>),
+        ([<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>],-<span class="hljs-number">1</span>),
+        ([<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">3</span>,[<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">2</span>]],-<span class="hljs-number">6</span>),
+        ([<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">3</span>,<span class="hljs-number">2</span>],<span class="hljs-number">9</span>),
+        ([<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">3</span>,<span class="hljs-number">2</span>]],<span class="hljs-number">10</span>),
+        ([<span class="hljs-string">&#x27;/&#x27;</span>,[<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;-&#x27;</span>,[<span class="hljs-string">&#x27;-&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">10</span>],
+         [<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">6</span>,[<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>]]],[<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>]]],<span class="hljs-number">2</span>],<span class="hljs-number">3</span>),
+        ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>]],<span class="hljs-number">1</span>),
+        ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">4</span>],<span class="hljs-number">1</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">1</span>],<span class="hljs-number">4</span>]],<span class="hljs-number">1</span>),
+        ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>]],<span class="hljs-number">4</span>),
+        ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>]],<span class="hljs-number">4</span>),
+        ([<span class="hljs-string">&#x27;add&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;mul&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>]],<span class="hljs-number">7</span>),
+        ]
+        <span class="hljs-keyword">for</span> xpr,res <span class="hljs-keyword">in</span> tests:
+            <span class="hljs-keyword">with</span> self.subTest(xpr=xpr,res=res):
+                self.assertEqual(self.j.<span class="hljs-built_in">eval</span>(xpr),res)
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_string_literal</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-keyword">with</span> self.assertRaisesRegex(JitError, <span class="hljs-string">&quot;unimplemented literal&quot;</span>):
+            self.j.<span class="hljs-built_in">eval</span>([<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-string">&#x27;dozen&#x27;</span>])
+
+    <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_too_complex</span>(<span class="hljs-params">self</span>):
+        <span class="hljs-keyword">def</span> <span class="hljs-title function_">sumtree</span>(<span class="hljs-params">d</span>):
+            <span class="hljs-keyword">return</span> <span class="hljs-number">1</span> <span class="hljs-keyword">if</span> d==<span class="hljs-number">0</span> <span class="hljs-keyword">else</span> [<span class="hljs-string">&#x27;+&#x27;</span>,sumtree(d-<span class="hljs-number">1</span>),sumtree(d-<span class="hljs-number">1</span>)]
+        <span class="hljs-keyword">with</span> self.assertRaisesRegex(JitError, <span class="hljs-string">&quot;too complex&quot;</span>):
+            self.j.<span class="hljs-built_in">eval</span>(sumtree(<span class="hljs-number">9</span>))
+
 <span class="hljs-keyword">if</span> __name__ == <span class="hljs-string">&quot;__main__&quot;</span>:
-    j = JitPage()
-
-    tests = [
-    (<span class="hljs-number">0</span>,<span class="hljs-number">0</span>),
-    ([<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>],-<span class="hljs-number">1</span>),
-    ([<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">3</span>,[<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">2</span>]],-<span class="hljs-number">6</span>),
-    ([<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">3</span>,<span class="hljs-number">2</span>],<span class="hljs-number">9</span>),
-    ([<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">3</span>,<span class="hljs-number">2</span>]],<span class="hljs-number">10</span>),
-    ([<span class="hljs-string">&#x27;/&#x27;</span>,[<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;-&#x27;</span>,[<span class="hljs-string">&#x27;-&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">10</span>],[<span class="hljs-string">&#x27;^&#x27;</span>,<span class="hljs-number">6</span>,[<span class="hljs-string">&#x27;+&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>]]],[<span class="hljs-string">&#x27;negate&#x27;</span>,<span class="hljs-number">1</span>]]],<span class="hljs-number">2</span>],<span class="hljs-number">3</span>),
-    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>]],<span class="hljs-number">1</span>),
-    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">4</span>],<span class="hljs-number">1</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">1</span>],<span class="hljs-number">4</span>]],<span class="hljs-number">1</span>),
-    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">1</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">1</span>],<span class="hljs-number">1</span>]],<span class="hljs-number">4</span>),
-    ([<span class="hljs-string">&#x27;+&#x27;</span>,[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>],[<span class="hljs-string">&#x27;*&#x27;</span>,[<span class="hljs-string">&#x27;&lt;=&#x27;</span>,<span class="hljs-number">4</span>,<span class="hljs-number">4</span>],<span class="hljs-number">4</span>]],<span class="hljs-number">4</span>),
-    ([<span class="hljs-string">&#x27;add&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;mul&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>]],<span class="hljs-number">7</span>),
-    ]
-
-    <span class="hljs-keyword">for</span> xpr,res <span class="hljs-keyword">in</span> tests:
-        <span class="hljs-built_in">print</span>(j.<span class="hljs-built_in">eval</span>(xpr) == res)
- 
-    <span class="hljs-keyword">try</span>:
-        j.<span class="hljs-built_in">eval</span>(<span class="hljs-string">&quot;1+&quot;</span>*<span class="hljs-number">500</span>+<span class="hljs-string">&quot;1&quot;</span>)
-        <span class="hljs-keyword">raise</span> Exception
-    <span class="hljs-keyword">except</span> JitError:
-        <span class="hljs-built_in">print</span>(<span class="hljs-literal">True</span>)</pre></div></div>
+    unittest.main()</pre></div></div>
             
         </li>
         

--- a/docs/packrat-parsing/index.html
+++ b/docs/packrat-parsing/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../just-in-time/index.html">
+                  ./just-in-time/index.py
+                </a>
+              
+                
                 <a class="source" href="index.html">
                   ./packrat-parsing/index.js
                 </a>

--- a/docs/precedence-climbing/index.html
+++ b/docs/precedence-climbing/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../just-in-time/index.html">
+                  ./just-in-time/index.py
+                </a>
+              
+                
                 <a class="source" href="../packrat-parsing/index.html">
                   ./packrat-parsing/index.js
                 </a>

--- a/docs/relational-db/index.html
+++ b/docs/relational-db/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../just-in-time/index.html">
+                  ./just-in-time/index.py
+                </a>
+              
+                
                 <a class="source" href="../packrat-parsing/index.html">
                   ./packrat-parsing/index.js
                 </a>

--- a/docs/virtual-dom/index.html
+++ b/docs/virtual-dom/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../just-in-time/index.html">
+                  ./just-in-time/index.py
+                </a>
+              
+                
                 <a class="source" href="../packrat-parsing/index.html">
                   ./packrat-parsing/index.js
                 </a>

--- a/just-in-time/index.py
+++ b/just-in-time/index.py
@@ -1,0 +1,220 @@
+# # An x86-64 (Mac/Linux) JIT demo in Python
+#
+# **License:** MIT
+# **Copyright:** (c) 2025 Dave Long
+#
+# In order to execute expressions parsed by Maxwell Bernstein's precedence
+# climbing [parser](https://pdubroy.github.io/200andchange/precedence-climbing/), we use a rudimentary assembler to put together threaded
+# opcode blocks in post-order, keeping our intermediates on the `rsp` stack.
+#
+# Obtaining an executable page and just-in-time loading the assembled code
+# into it is accomplished via the help of `ctypes`, on SYSV ABI platforms.
+# ------------------------------------------------------------------------------
+
+from ctypes      import cast, CFUNCTYPE, POINTER, pythonapi
+from ctypes      import c_char, c_int, c_long, c_char_p, c_void_p, c_size_t
+from dataclasses import dataclass, field
+from os          import name
+from platform    import processor, machine
+from sys         import maxsize
+from typing      import List, Tuple
+
+class JitError(Exception):
+    pass
+
+# ------------------------------------------------------------------------------
+
+# `Asm` builds an assembled expression. Most opcodes are position-independent,
+# and are kept in the `ops` array, but call offsets are `rip`-relative and
+# hence vary at runtime, so we keep relocations in the `rels` array for them.
+@dataclass
+class Asm:
+    ops: List[int]             = field(default_factory=list)
+    rels: List[Tuple[int,int]] = field(default_factory=list)
+
+    # `dot` returns the current offset relative to the start
+    def dot(self) -> int:
+        return len(self.ops)
+
+    # `db` defines bytes, which we use to specify opcodes
+    # in lieu of a more powerful assembler
+    def db(self, v: List[int]):
+        self.ops.extend(v)
+
+    # `dd` defines a (little endian) dword
+    def dd(self, v: int):
+        self.db([(v>>8*i)&0xff for i in range(4)])
+
+    # `dq` defines a (little endian) quadword
+    def dq(self, v: int):
+        self.db([(v>>8*i)&0xff for i in range(8)])
+
+    # `reloc` defines a relocation entry specifying
+    # opcode data which must be fixed up at load time
+    def reloc(self, dst: int):
+        self.rels.append((self.dot(), dst))
+        self.dd(0)
+
+# Assemble 0-address threaded code blocks for the various operations.
+# (See also some of [dmr's threaded code](http://squoze.net/NB/nbilib.s))
+def add(a):
+    a.db([0x59,0x58,0x48,0x01,0xc8,0x50])
+
+def sub(a):
+    a.db([0x59,0x58,0x48,0x29,0xc8,0x50])
+
+def mul(a):
+    a.db([0x59,0x58,0x48,0xf7,0xe9,0x50])
+
+def div(a):
+    a.db([0x59,0x58,0x48,0x99,0x48,0xf7,0xf9,0x50])
+
+def leq(a):
+    a.db([0x59,0x58,0x48,0xff,0xc1,0x48,0x29,0xc8,0x48,0x99])
+    a.db([0x48,0x83,0xe2,0x01,0x52])
+
+def lt(a):
+    a.db([0x59,0x58,0x48,0x29,0xc8,0x48,0x99,0x48,0x83,0xe2,0x01,0x52])
+
+def neg(a):
+    a.db([0x59,0x48,0x31,0xc0,0x48,0x29,0xc8,0x50])
+
+# to handle `^` we call back into python code
+@CFUNCTYPE(c_long, c_long,c_long)
+def py_exp(a,b):
+    return a**b if 0<=b else 0 # not quite right
+
+def exp(a):
+    a.db([0x5e,0x5f,0x53,0x48,0x89,0xe3,0x48,0x83,0xe3,0x08,0x48,0x29,0xdc])
+    a.db([0xe8]); a.reloc(cast(py_exp,c_void_p).value)
+    a.db([0x48,0x01,0xdc,0x5b,0x50])
+
+# for simplicity `lit`eral data is always coded as a quad immediate
+def lit(a,v):
+    a.db([0x48,0xb8]); a.dq(v)
+    a.db([0x50])
+
+# given a concrete syntax tree, `codegen` assembles the threaded
+# code blocks in order to calculate its value
+def codegen(a:Asm, cst) -> Asm:
+    gentab = {
+    ('+',2): add, ('-',2): sub,
+    ('*',2): mul, ('/',2): div,
+    ('^',2): exp, ('negate',1): neg,
+    ('<=',2): leq, ('<',2): lt,
+    # allow ascii-syntax operations as well
+    ('add',2): add, ('sub',2): sub,
+    ('mul',2): mul, ('div',2): div,
+    ('exp',2): exp,
+    }
+ 
+    # `gen` does a syntax-directed tree walk. Gen of
+    # `['+',1,['*',2,3]]` assembles the concatenation `<1> <2> <3> * +`
+    def gen(a:Asm, cst):
+        if isinstance(cst,int):
+            lit(a,cst)
+        elif isinstance(cst,list):
+            key = (cst[0],len(cst)-1)
+            if key in gentab:
+                # we process the syntax tree in postorder
+                for arg in cst[1:]:
+                  gen(a,arg)
+                gentab[key](a)
+            else:
+                raise JitError("unimplemented func")
+        else:
+            raise JitError("unimplemented literal")
+ 
+    gen(a, cst)
+    a.db([0x58,0xc3])
+    return a
+
+# ------------------------------------------------------------------------------
+
+Thunk = CFUNCTYPE(c_long)
+
+# `JitPage` grubs around with `ctypes` to load and execute the assembled code.
+# The address of our executable page is `adr` and it extends `len` bytes.
+class JitPage:
+    valid: bool
+    adr: int
+    len: int
+
+    def __init__(self):
+        # there *has* to be a better way to check for SYSV x86-64!?
+        if name != 'posix' or maxsize != 2**63-1 or (not
+           any("86" in f for f in [processor(),machine()])):
+            self.len   = 0
+            self.adr   = 0
+            self.valid = False
+        else:
+            # establish some libc linkages
+            mc  = pythonapi.memcpy
+            mc.argtypes = (c_void_p,c_char_p,c_size_t)
+            ms  = pythonapi.memset
+            ms.argtypes = (c_void_p,c_char,c_size_t)
+            mm  = pythonapi.mmap
+            mm.restype = c_void_p
+            mm.argtype = (c_void_p,c_size_t,c_int,c_int,c_int,c_size_t)
+            # allocate RWX page
+            self.len   = pythonapi.getpagesize()
+            self.adr   = pythonapi.mmap(0, self.len, 7, 0x1022, -1, 0)
+            self.valid = True
+
+    # `fixup` is called if necessary at load time to encode `rip`-relative
+    # offsets between our calls and their referents
+    def fixup(self, off:int, dst:int):
+        # assumption: our page and ctypes' thunks are within 32 bits
+        adr = self.adr+off
+        rel = dst - (adr+4)
+        buf = cast(adr, POINTER(c_char*4)).contents
+        buf[:] = [(rel>>8*i)&0xff for i in range(4)]
+
+    # `load` copies assembled code into the RWX page,
+    # returning a function pointer to the start of the assembly.
+    def load(self, a:Asm) -> Thunk:
+        if not self.valid:
+            raise JitError("couldn't confirm posix x86-64")
+        if a.dot() > self.len:
+            raise JitError("too complex")
+        # fill with breakpoints
+        pythonapi.memset(self.adr, 0xcc, self.len)
+        # load in the opcodes
+        pythonapi.memcpy(self.adr, bytes(a.ops), a.dot())
+        # fix up relative references
+        for off,dst in a.rels:
+            self.fixup(off,dst)
+        return Thunk(self.adr)
+
+    # `eval` assembles code for a parsed expression, loads, and executes
+    def eval(self, expr) -> int:
+        thunk = self.load(codegen(Asm(), expr))
+        return thunk()
+
+# ------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    j = JitPage()
+
+    tests = [
+    (0,0),
+    (['negate',1],-1),
+    (['*',3,['negate',2]],-6),
+    (['^',3,2],9),
+    (['+',1,['^',3,2]],10),
+    (['/',['+',1,['-',['-',['*',4,10],['^',6,['+',1,1]]],['negate',1]]],2],3),
+    (['+',['*',['<',1,1],1],['*',['<=',1,1],1]],1),
+    (['+',['*',['<',1,4],1],['*',['<=',4,1],4]],1),
+    (['+',['*',['<',1,4],4],['*',['<=',4,1],1]],4),
+    (['+',['*',['<',4,4],4],['*',['<=',4,4],4]],4),
+    (['add',1,['mul',2,3]],7),
+    ]
+
+    for xpr,res in tests:
+        print(j.eval(xpr) == res)
+ 
+    try:
+        j.eval("1+"*500+"1")
+        raise Exception
+    except JitError:
+        print(True)


### PR DESCRIPTION
Adds a ~200 line JIT that's meant to function with the existing 200andchange precedence parser.

It only targets SYSV ABI x86-64 (tested on Mac, Alpine, and Ubuntu), but the means of detecting this at runtime is probably brittle.