### PR TITLE
A JSON parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ There's something magical about demonstrating a powerful concept with ~250 lines
 * [Relational DB](./relational-db/)
 * [Precedence climbing parser](./precedence-climbing/)
 * [JIT](./just-in-time/)
+* [JSON parser](./json-parser/)
 
 ## Contributing
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
 <li><a href="./relational-db/">Relational DB</a></li>
 <li><a href="./precedence-climbing/">Precedence climbing parser</a></li>
 <li><a href="./just-in-time/">JIT</a></li>
+<li><a href="./json-parser/">JSON parser</a></li>
 </ul>
 <h2>Contributing</h2>
 <p>Want to add a new example, or help annotate an existing one? <a href="https://github.com/pdubroy/200andchange">Open a PR</a>.</p>

--- a/docs/json-parser/index.html
+++ b/docs/json-parser/index.html
@@ -93,13 +93,14 @@ style.</p>
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-meta">{-# LANGUAGE TupleSections, LambdaCase #-}</span>
+            <div class="content"><div class='highlight'><pre><span class="hljs-meta">{-# LANGUAGE LambdaCase, TupleSections #-}</span>
+
 <span class="hljs-keyword">module</span> JSONParser <span class="hljs-keyword">where</span>
 
-<span class="hljs-keyword">import</span> Control.Applicative (<span class="hljs-type">Alternative(..)</span>, <span class="hljs-title">optional</span>)
+<span class="hljs-keyword">import</span> Control.Applicative (<span class="hljs-type">Alternative</span> (..), optional)
 <span class="hljs-keyword">import</span> Control.Monad (<span class="hljs-title">replicateM</span>)
 <span class="hljs-keyword">import</span> Data.Bits (<span class="hljs-title">shiftL</span>)
-<span class="hljs-keyword">import</span> Data.Char (<span class="hljs-title">isDigit</span>, <span class="hljs-title">isHexDigit</span>, <span class="hljs-title">chr</span>, <span class="hljs-title">ord</span>, <span class="hljs-title">digitToInt</span>)
+<span class="hljs-keyword">import</span> Data.Char (<span class="hljs-title">chr</span>, <span class="hljs-title">digitToInt</span>, <span class="hljs-title">isDigit</span>, <span class="hljs-title">isHexDigit</span>, <span class="hljs-title">ord</span>)
 <span class="hljs-keyword">import</span> Data.Functor (($&gt;))
 <span class="hljs-keyword">import</span> System.Exit (<span class="hljs-title">exitFailure</span>)</pre></div></div>
             
@@ -116,7 +117,8 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">data</span> <span class="hljs-type">JValue</span> =</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">data</span> <span class="hljs-type">JValue</span></span>
+  =</pre></div></div>
             
         </li>
         
@@ -131,7 +133,7 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>              <span class="hljs-type">JNull</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-type">JNull</span></pre></div></div>
             
         </li>
         
@@ -146,7 +148,7 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JBool</span> <span class="hljs-type">Bool</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre>  | <span class="hljs-type">JBool</span> <span class="hljs-type">Bool</span></pre></div></div>
             
         </li>
         
@@ -161,7 +163,7 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JString</span> <span class="hljs-type">String</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre>  | <span class="hljs-type">JString</span> <span class="hljs-type">String</span></pre></div></div>
             
         </li>
         
@@ -176,7 +178,7 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JNumber</span> { int :: <span class="hljs-type">Integer</span>, frac :: [<span class="hljs-type">Int</span>], exponent :: <span class="hljs-type">Integer</span> }</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  | <span class="hljs-type">JNumber</span> {int :: <span class="hljs-type">Integer</span>, frac :: [<span class="hljs-type">Int</span>], exponent :: <span class="hljs-type">Integer</span>}</pre></div></div>
             
         </li>
         
@@ -191,7 +193,7 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JArray</span> [<span class="hljs-type">JValue</span>]</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  | <span class="hljs-type">JArray</span> [<span class="hljs-type">JValue</span>]</pre></div></div>
             
         </li>
         
@@ -206,8 +208,8 @@ style.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JObject</span> [(<span class="hljs-type">String</span>, <span class="hljs-type">JValue</span>)]
-            <span class="hljs-keyword">deriving</span> (<span class="hljs-type">Eq</span>)</pre></div></div>
+            <div class="content"><div class='highlight'><pre>  | <span class="hljs-type">JObject</span> [(<span class="hljs-type">String</span>, <span class="hljs-type">JValue</span>)]
+  <span class="hljs-keyword">deriving</span> (<span class="hljs-type">Eq</span>)</pre></div></div>
             
         </li>
         
@@ -223,8 +225,7 @@ relevant data structure <code>o</code> and the rest of the input <code>i</code> 
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">newtype</span> <span class="hljs-type">Parser</span> i o =</span>
-  <span class="hljs-type">Parser</span> { runParser :: i -&gt; <span class="hljs-type">Maybe</span> (i, o) }</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">newtype</span> <span class="hljs-type">Parser</span> i o = <span class="hljs-type">Parser</span> {<span class="hljs-title">runParser</span> :: <span class="hljs-title">i</span> -&gt; <span class="hljs-type">Maybe</span> (<span class="hljs-title">i</span>, <span class="hljs-title">o</span>)}</span></pre></div></div>
             
         </li>
         
@@ -259,9 +260,9 @@ This allows us to combine the results of two parsers that are independent of eac
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">instance</span> <span class="hljs-type">Applicative</span> (<span class="hljs-type">Parser</span> <span class="hljs-title">i</span>) <span class="hljs-keyword">where</span></span>
-  pure x    = <span class="hljs-type">Parser</span> $ pure . (, x)
+  pure x = <span class="hljs-type">Parser</span> $ pure . (,x)
   pf &lt;*&gt; po = <span class="hljs-type">Parser</span> $ \input -&gt; <span class="hljs-keyword">case</span> runParser pf input <span class="hljs-keyword">of</span>
-    <span class="hljs-type">Nothing</span>        -&gt; <span class="hljs-type">Nothing</span>
+    <span class="hljs-type">Nothing</span> -&gt; <span class="hljs-type">Nothing</span>
     <span class="hljs-type">Just</span> (rest, f) -&gt; fmap f &lt;$&gt; runParser po rest</pre></div></div>
             
         </li>
@@ -299,7 +300,7 @@ dependent on the result of other.</p>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">instance</span> <span class="hljs-type">Monad</span> (<span class="hljs-type">Parser</span> <span class="hljs-title">i</span>) <span class="hljs-keyword">where</span></span>
   p &gt;&gt;= f = <span class="hljs-type">Parser</span> $ \input -&gt; <span class="hljs-keyword">case</span> runParser p input <span class="hljs-keyword">of</span>
-    <span class="hljs-type">Nothing</span>        -&gt; <span class="hljs-type">Nothing</span>
+    <span class="hljs-type">Nothing</span> -&gt; <span class="hljs-type">Nothing</span>
     <span class="hljs-type">Just</span> (rest, o) -&gt; runParser (f o) rest</pre></div></div>
             
         </li>
@@ -318,8 +319,8 @@ Returns the matching element on success.</p>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">satisfy</span> :: (a -&gt; <span class="hljs-type">Bool</span>) -&gt; <span class="hljs-type">Parser</span> [a] a
 <span class="hljs-title">satisfy</span> predicate = <span class="hljs-type">Parser</span> $ \<span class="hljs-keyword">case</span>
-  (x:xs) | predicate x -&gt; <span class="hljs-type">Just</span> (xs, x)
-  _                    -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
+  (x : xs) | predicate x -&gt; <span class="hljs-type">Just</span> (xs, x)
+  _ -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
             
         </li>
         
@@ -367,8 +368,8 @@ Returns the matching element on success.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">string</span> :: <span class="hljs-type">String</span> -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">String</span>
-<span class="hljs-title">string</span> <span class="hljs-string">&quot;&quot;</span>     = pure <span class="hljs-string">&quot;&quot;</span>
-<span class="hljs-title">string</span> (c:cs) = (:) &lt;$&gt; char c &lt;*&gt; string cs</pre></div></div>
+<span class="hljs-title">string</span> <span class="hljs-string">&quot;&quot;</span> = pure <span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-title">string</span> (c : cs) = (:) &lt;$&gt; char c &lt;*&gt; string cs</pre></div></div>
             
         </li>
         
@@ -402,8 +403,9 @@ corresponding <code>JBool</code> value on success.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">jBool</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
-<span class="hljs-title">jBool</span> =   string <span class="hljs-string">&quot;true&quot;</span>  $&gt; <span class="hljs-type">JBool</span> <span class="hljs-type">True</span>
-      &lt;|&gt; string <span class="hljs-string">&quot;false&quot;</span> $&gt; <span class="hljs-type">JBool</span> <span class="hljs-type">False</span></pre></div></div>
+<span class="hljs-title">jBool</span> =
+  string <span class="hljs-string">&quot;true&quot;</span> $&gt; <span class="hljs-type">JBool</span> <span class="hljs-type">True</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;false&quot;</span> $&gt; <span class="hljs-type">JBool</span> <span class="hljs-type">False</span></pre></div></div>
             
         </li>
         
@@ -420,16 +422,17 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">jsonChar</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">Char</span>
-<span class="hljs-title">jsonChar</span> =   string <span class="hljs-string">&quot;\\\&quot;&quot;</span> $&gt; <span class="hljs-string">&#x27;&quot;&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\\\&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\/&quot;</span>  $&gt; <span class="hljs-string">&#x27;/&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\b&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\b</span>&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\f&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\f</span>&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\n&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\n</span>&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\r&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\r</span>&#x27;</span>
-         &lt;|&gt; string <span class="hljs-string">&quot;\\t&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\t</span>&#x27;</span>
-         &lt;|&gt; unicodeChar
-         &lt;|&gt; satisfy (\c -&gt; not (c == <span class="hljs-string">&#x27;<span class="hljs-char escape_">\&quot;</span>&#x27;</span> || c == <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span> || isControl c))
+<span class="hljs-title">jsonChar</span> =
+  string <span class="hljs-string">&quot;\\\&quot;&quot;</span> $&gt; <span class="hljs-string">&#x27;&quot;&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\\\&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\/&quot;</span> $&gt; <span class="hljs-string">&#x27;/&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\b&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\b</span>&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\f&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\f</span>&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\n&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\n</span>&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\r&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\r</span>&#x27;</span>
+  &lt;|&gt; string <span class="hljs-string">&quot;\\t&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\t</span>&#x27;</span>
+  &lt;|&gt; unicodeChar
+  &lt;|&gt; satisfy (\c -&gt; not (c == <span class="hljs-string">&#x27;<span class="hljs-char escape_">\&quot;</span>&#x27;</span> || c == <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span> || isControl c))
   <span class="hljs-keyword">where</span>
     unicodeChar =
       chr . fromIntegral . digitsToNumber <span class="hljs-number">16</span> <span class="hljs-number">0</span>
@@ -462,29 +465,30 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
     jString&#x27; = <span class="hljs-keyword">do</span>
       optFirst &lt;- optional jsonChar
       <span class="hljs-keyword">case</span> optFirst <span class="hljs-keyword">of</span>
-        <span class="hljs-type">Nothing</span> -&gt; <span class="hljs-string">&quot;&quot;</span> &lt;$ char <span class="hljs-string">&#x27;&quot;&#x27;</span>
-        <span class="hljs-type">Just</span> first | not (isSurrogate first) -&gt;
-          (first:) &lt;$&gt; jString&#x27;
+        <span class="hljs-type">Nothing</span> -&gt; char <span class="hljs-string">&#x27;&quot;&#x27;</span> $&gt; <span class="hljs-string">&quot;&quot;</span>
+        <span class="hljs-type">Just</span> first | not (isSurrogate first) -&gt; (first :) &lt;$&gt; jString&#x27;
         <span class="hljs-type">Just</span> first -&gt; <span class="hljs-keyword">do</span>
           second &lt;- jsonChar
           <span class="hljs-keyword">if</span> isHighSurrogate first &amp;&amp; isLowSurrogate second
-          <span class="hljs-keyword">then</span> (combineSurrogates first second :) &lt;$&gt; jString&#x27;
-          <span class="hljs-keyword">else</span> empty
+            <span class="hljs-keyword">then</span> (combineSurrogates first second :) &lt;$&gt; jString&#x27;
+            <span class="hljs-keyword">else</span> empty
 
     isHighSurrogate a =
       ord a &gt;= highSurrogateLowerBound &amp;&amp; ord a &lt;= highSurrogateUpperBound
-    isLowSurrogate a  =
+    isLowSurrogate a =
       ord a &gt;= lowSurrogateLowerBound &amp;&amp; ord a &lt;= lowSurrogateUpperBound
-    isSurrogate a     = isHighSurrogate a || isLowSurrogate a
+    isSurrogate a = isHighSurrogate a || isLowSurrogate a
 
-    combineSurrogates a b = chr $
-      ((ord a - highSurrogateLowerBound) `shiftL` <span class="hljs-number">10</span>)
-      + (ord b - lowSurrogateLowerBound) + <span class="hljs-number">0x10000</span>
+    combineSurrogates a b =
+      chr $
+        ((ord a - highSurrogateLowerBound) `shiftL` <span class="hljs-number">10</span>)
+          + (ord b - lowSurrogateLowerBound)
+          + <span class="hljs-number">0x10000</span>
 
     highSurrogateLowerBound = <span class="hljs-number">0xD800</span>
     highSurrogateUpperBound = <span class="hljs-number">0xDBFF</span>
-    lowSurrogateLowerBound  = <span class="hljs-number">0xDC00</span>
-    lowSurrogateUpperBound  = <span class="hljs-number">0xDFFF</span></pre></div></div>
+    lowSurrogateLowerBound = <span class="hljs-number">0xDC00</span>
+    lowSurrogateUpperBound = <span class="hljs-number">0xDFFF</span></pre></div></div>
             
         </li>
         
@@ -508,29 +512,20 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
     jIntFracExp = (\ ~(<span class="hljs-type">JNumber</span> i f _) e -&gt; <span class="hljs-type">JNumber</span> i f e) &lt;$&gt; jIntFrac &lt;*&gt; jExp
 
     jInt&#x27; = signInt &lt;$&gt; optional (char <span class="hljs-string">&#x27;-&#x27;</span>) &lt;*&gt; jUInt
-    jUInt =   (\d ds -&gt; digitsToNumber <span class="hljs-number">10</span> <span class="hljs-number">0</span> (d:ds)) &lt;$&gt; digit19 &lt;*&gt; digits
-          &lt;|&gt; fromIntegral &lt;$&gt; digit
+    jUInt =
+      (\d ds -&gt; digitsToNumber <span class="hljs-number">10</span> <span class="hljs-number">0</span> (d : ds)) &lt;$&gt; digit19 &lt;*&gt; digits
+      &lt;|&gt; fromIntegral &lt;$&gt; digit
 
     jFrac = char <span class="hljs-string">&#x27;.&#x27;</span> *&gt; digits
-    jExp = (char <span class="hljs-string">&#x27;e&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;E&#x27;</span>)
-      *&gt; (signInt &lt;$&gt; optional (char <span class="hljs-string">&#x27;+&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;-&#x27;</span>) &lt;*&gt; jUInt)
+    jExp =
+      (char <span class="hljs-string">&#x27;e&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;E&#x27;</span>)
+        *&gt; (signInt &lt;$&gt; optional (char <span class="hljs-string">&#x27;+&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;-&#x27;</span>) &lt;*&gt; jUInt)
 
     digit19 = digitToInt &lt;$&gt; satisfy (\x -&gt; isDigit x &amp;&amp; x /= <span class="hljs-string">&#x27;0&#x27;</span>)
     digits = some digit
 
     signInt (<span class="hljs-type">Just</span> <span class="hljs-string">&#x27;-&#x27;</span>) i = negate i
-    signInt _          i = i
-
-<span class="hljs-title">surroundedBy</span> ::
-  <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> a -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> b -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> a
-<span class="hljs-title">surroundedBy</span> p1 p2 = p2 *&gt; p1 &lt;* p2
-
-<span class="hljs-title">separatedBy</span> :: <span class="hljs-type">Parser</span> i v -&gt; <span class="hljs-type">Parser</span> i s -&gt; <span class="hljs-type">Parser</span> i [v]
-<span class="hljs-title">separatedBy</span> v s =   (:) &lt;$&gt; v &lt;*&gt; many (s *&gt; v)
-                &lt;|&gt; pure []
-
-<span class="hljs-title">spaces</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">String</span>
-<span class="hljs-title">spaces</span> = many (char <span class="hljs-string">&#x27; &#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\n</span>&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\r</span>&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\t</span>&#x27;</span>)</pre></div></div>
+    signInt _ i = i</pre></div></div>
             
         </li>
         
@@ -541,15 +536,23 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
               <div class="sswrap ">
                 <a class="ss" href="#section-24">&#x00a7;</a>
               </div>
-              <p>The parser for JSON arrays, containing zero or more items of any JSON types separated by commas.</p>
+              <p>Some handy parser combinators</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-title">jArray</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
-<span class="hljs-title">jArray</span> = <span class="hljs-type">JArray</span> &lt;$&gt;
-  (char <span class="hljs-string">&#x27;[&#x27;</span>
-   *&gt; (jValue `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces)
-   &lt;* char <span class="hljs-string">&#x27;]&#x27;</span>)</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">surroundedBy</span> :: <span class="hljs-type">Parser</span> i a -&gt; <span class="hljs-type">Parser</span> i b -&gt; <span class="hljs-type">Parser</span> i a
+<span class="hljs-title">surroundedBy</span> p1 p2 = p2 *&gt; p1 &lt;* p2
+
+<span class="hljs-title">separatedBy</span> :: <span class="hljs-type">Parser</span> i v -&gt; <span class="hljs-type">Parser</span> i s -&gt; <span class="hljs-type">Parser</span> i [v]
+<span class="hljs-title">separatedBy</span> v s =
+  (:) &lt;$&gt; v &lt;*&gt; many (s *&gt; v)
+  &lt;|&gt; pure []
+
+<span class="hljs-title">between</span> :: <span class="hljs-type">Parser</span> i a -&gt; <span class="hljs-type">Parser</span> i a -&gt; <span class="hljs-type">Parser</span> i b -&gt; <span class="hljs-type">Parser</span> i b
+<span class="hljs-title">between</span> pl pr p = pl *&gt; p &lt;* pr
+
+<span class="hljs-title">spaces</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">String</span>
+<span class="hljs-title">spaces</span> = many (char <span class="hljs-string">&#x27; &#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\n</span>&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\r</span>&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\t</span>&#x27;</span>)</pre></div></div>
             
         </li>
         
@@ -560,19 +563,14 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
               <div class="sswrap ">
                 <a class="ss" href="#section-25">&#x00a7;</a>
               </div>
-              <p>The parser for JSON objects, containing  zero or more key-value pairs separated by colon, where
-keys are JSON strings, and values are any JSON types.</p>
+              <p>The parser for JSON arrays, containing zero or more items of any JSON types separated by commas.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-title">jObject</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
-<span class="hljs-title">jObject</span> = <span class="hljs-type">JObject</span> &lt;$&gt;
-  (char <span class="hljs-string">&#x27;{&#x27;</span> *&gt; pair `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces &lt;* char <span class="hljs-string">&#x27;}&#x27;</span>)
-  <span class="hljs-keyword">where</span>
-    pair = (\ ~(<span class="hljs-type">JString</span> s) j -&gt; (s, j))
-      &lt;$&gt; (jString `surroundedBy` spaces)
-      &lt;*  char <span class="hljs-string">&#x27;:&#x27;</span>
-      &lt;*&gt; jValue</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jArray</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jArray</span> = fmap <span class="hljs-type">JArray</span>
+  . between (char <span class="hljs-string">&#x27;[&#x27;</span>) (char <span class="hljs-string">&#x27;]&#x27;</span>)
+  $ jValue `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces</pre></div></div>
             
         </li>
         
@@ -583,19 +581,21 @@ keys are JSON strings, and values are any JSON types.</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-26">&#x00a7;</a>
               </div>
-              <p>The parser for any JSON value, created by combining all the previous JSON parsers.</p>
+              <p>The parser for JSON objects, containing  zero or more key-value pairs separated by colon, where
+keys are JSON strings, and values are any JSON types.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-title">jValue</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
-<span class="hljs-title">jValue</span> = jValue&#x27; `surroundedBy` spaces
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jObject</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jObject</span> = fmap <span class="hljs-type">JObject</span>
+  . between (char <span class="hljs-string">&#x27;{&#x27;</span>) ( char <span class="hljs-string">&#x27;}&#x27;</span>)
+  $ pair `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces
   <span class="hljs-keyword">where</span>
-    jValue&#x27; =   jNull
-            &lt;|&gt; jBool
-            &lt;|&gt; jString
-            &lt;|&gt; jNumber
-            &lt;|&gt; jArray
-            &lt;|&gt; jObject</pre></div></div>
+    pair =
+      (\ ~(<span class="hljs-type">JString</span> s) j -&gt; (s, j))
+        &lt;$&gt; (jString `surroundedBy` spaces)
+        &lt;* char <span class="hljs-string">&#x27;:&#x27;</span>
+        &lt;*&gt; jValue</pre></div></div>
             
         </li>
         
@@ -606,14 +606,20 @@ keys are JSON strings, and values are any JSON types.</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-27">&#x00a7;</a>
               </div>
-              <p><code>parseJSON</code> parses its input string as a JSON value, or fails on parsing errors.</p>
+              <p>The parser for any JSON value, created by combining all the previous JSON parsers.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-title">parseJSON</span> :: <span class="hljs-type">String</span> -&gt; <span class="hljs-type">Maybe</span> <span class="hljs-type">JValue</span>
-<span class="hljs-title">parseJSON</span> s = <span class="hljs-keyword">case</span> runParser jValue s <span class="hljs-keyword">of</span>
-  <span class="hljs-type">Just</span> (<span class="hljs-string">&quot;&quot;</span>, j) -&gt; <span class="hljs-type">Just</span> j
-  _            -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jValue</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jValue</span> = jValue&#x27; `surroundedBy` spaces
+  <span class="hljs-keyword">where</span>
+    jValue&#x27; =
+      jNull
+        &lt;|&gt; jBool
+        &lt;|&gt; jString
+        &lt;|&gt; jNumber
+        &lt;|&gt; jArray
+        &lt;|&gt; jObject</pre></div></div>
             
         </li>
         
@@ -624,15 +630,34 @@ keys are JSON strings, and values are any JSON types.</p>
               <div class="sswrap ">
                 <a class="ss" href="#section-28">&#x00a7;</a>
               </div>
+              <p><code>parseJSON</code> parses its input string as a JSON value, or fails on parsing errors.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">parseJSON</span> :: <span class="hljs-type">String</span> -&gt; <span class="hljs-type">Maybe</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">parseJSON</span> s = <span class="hljs-keyword">case</span> runParser jValue s <span class="hljs-keyword">of</span>
+  <span class="hljs-type">Just</span> (<span class="hljs-string">&quot;&quot;</span>, j) -&gt; <span class="hljs-type">Just</span> j
+  _ -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-29">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-29">&#x00a7;</a>
+              </div>
               <p><code>main</code> function reads text from standard input, and parses it as a JSON value.
 Prints a message indicating whether parsing succeeded or failed.</p>
 
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">main</span> :: <span class="hljs-type">IO</span> ()
-<span class="hljs-title">main</span> = getContents &gt;&gt;= \input -&gt; <span class="hljs-keyword">case</span> parseJSON input <span class="hljs-keyword">of</span>
-  <span class="hljs-type">Just</span> _ -&gt; putStrLn <span class="hljs-string">&quot;Parse okay&quot;</span>
-  <span class="hljs-type">Nothing</span> -&gt; putStrLn <span class="hljs-string">&quot;Parse failed&quot;</span> &gt;&gt; exitFailure</pre></div></div>
+<span class="hljs-title">main</span> =
+  getContents &gt;&gt;= \input -&gt; <span class="hljs-keyword">case</span> parseJSON input <span class="hljs-keyword">of</span>
+    <span class="hljs-type">Just</span> _ -&gt; putStrLn <span class="hljs-string">&quot;Parse okay&quot;</span>
+    <span class="hljs-type">Nothing</span> -&gt; putStrLn <span class="hljs-string">&quot;Parse failed&quot;</span> &gt;&gt; exitFailure</pre></div></div>
             
         </li>
         

--- a/docs/json-parser/index.html
+++ b/docs/json-parser/index.html
@@ -68,7 +68,7 @@
 <p><strong>License:</strong> MIT</p>
 <p><strong>Copyright:</strong> (c) 2025 <a href="https://abhinavsarkar.net">Abhinav Sarkar</a>, Google</p>
 <p>This is a <a href="https://en.wikipedia.org/wiki/JSON">JSON</a> parser written from scratch in <a href="https://www.haskell.org/">Haskell</a>
-in 183 lines. It complies with the JSON language specification set out in <a href="https://tools.ietf.org/html/rfc8259">IETF RFC 8259</a>,
+in under 200 lines. It complies with the JSON language specification set out in <a href="https://tools.ietf.org/html/rfc8259">IETF RFC 8259</a>,
 and passes the comprehensive <a href="https://github.com/nst/JSONTestSuite">JSON test suite</a>.</p>
 <p>It is a recursive-descent parser, written in <a href="https://en.wikipedia.org/wiki/Parser_combinator">Parser combinator</a>
 style.</p>

--- a/docs/json-parser/index.html
+++ b/docs/json-parser/index.html
@@ -93,9 +93,7 @@ style.</p>
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-meta">{-# LANGUAGE LambdaCase, TupleSections #-}</span>
-
-<span class="hljs-keyword">module</span> JSONParser <span class="hljs-keyword">where</span>
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">module</span> JSONParser <span class="hljs-keyword">where</span>
 
 <span class="hljs-keyword">import</span> Control.Applicative (<span class="hljs-type">Alternative</span> (..), optional)
 <span class="hljs-keyword">import</span> Control.Monad (<span class="hljs-title">replicateM</span>)
@@ -318,7 +316,7 @@ Returns the matching element on success.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">satisfy</span> :: (a -&gt; <span class="hljs-type">Bool</span>) -&gt; <span class="hljs-type">Parser</span> [a] a
-<span class="hljs-title">satisfy</span> predicate = <span class="hljs-type">Parser</span> $ \<span class="hljs-keyword">case</span>
+<span class="hljs-title">satisfy</span> predicate = <span class="hljs-type">Parser</span> $ \input -&gt; <span class="hljs-keyword">case</span> input <span class="hljs-keyword">of</span>
   (x : xs) | predicate x -&gt; <span class="hljs-type">Just</span> (xs, x)
   _ -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
             
@@ -536,7 +534,7 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
               <div class="sswrap ">
                 <a class="ss" href="#section-24">&#x00a7;</a>
               </div>
-              <p>Some handy parser combinators</p>
+              <p>Some handy parser combinators.</p>
 
             </div>
             
@@ -569,7 +567,7 @@ for characters defined in the JSON spec, and Unicode characters with <code>\u</c
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">jArray</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
 <span class="hljs-title">jArray</span> = fmap <span class="hljs-type">JArray</span>
-  . between (char <span class="hljs-string">&#x27;[&#x27;</span>) (char <span class="hljs-string">&#x27;]&#x27;</span>)
+  $ between (char <span class="hljs-string">&#x27;[&#x27;</span>) (char <span class="hljs-string">&#x27;]&#x27;</span>)
   $ jValue `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces</pre></div></div>
             
         </li>
@@ -588,7 +586,7 @@ keys are JSON strings, and values are any JSON types.</p>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-title">jObject</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
 <span class="hljs-title">jObject</span> = fmap <span class="hljs-type">JObject</span>
-  . between (char <span class="hljs-string">&#x27;{&#x27;</span>) ( char <span class="hljs-string">&#x27;}&#x27;</span>)
+  $ between (char <span class="hljs-string">&#x27;{&#x27;</span>) ( char <span class="hljs-string">&#x27;}&#x27;</span>)
   $ pair `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces
   <span class="hljs-keyword">where</span>
     pair =

--- a/docs/json-parser/index.html
+++ b/docs/json-parser/index.html
@@ -1,0 +1,642 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>A JSON parser in Haskell</title>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <link rel="stylesheet" media="all" href="../docco.css" />
+</head>
+<body>
+  <div id="container">
+    <div id="background"></div>
+    
+      <ul id="jump_to">
+        <li>
+          <a class="large" href="javascript:void(0);">Jump To &hellip;</a>
+          <a class="small" href="javascript:void(0);">+</a>
+          <div id="jump_wrapper">
+          <div id="jump_page_wrapper">
+            <div id="jump_page">
+              
+                
+                <a class="source" href="index.html">
+                  ./json-parser/index.hs
+                </a>
+              
+                
+                <a class="source" href="../just-in-time/index.html">
+                  ./just-in-time/index.py
+                </a>
+              
+                
+                <a class="source" href="../packrat-parsing/index.html">
+                  ./packrat-parsing/index.js
+                </a>
+              
+                
+                <a class="source" href="../precedence-climbing/index.html">
+                  ./precedence-climbing/index.py
+                </a>
+              
+                
+                <a class="source" href="../relational-db/index.html">
+                  ./relational-db/index.py
+                </a>
+              
+                
+                <a class="source" href="../virtual-dom/index.html">
+                  ./virtual-dom/index.js
+                </a>
+              
+            </div>
+          </div>
+        </li>
+      </ul>
+    
+    <ul class="sections">
+        
+        
+        
+        <li id="section-1">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-1">&#x00a7;</a>
+              </div>
+              <h1 id="a-json-parser-in-haskell">A JSON parser in Haskell</h1>
+<p><strong>License:</strong> MIT</p>
+<p><strong>Copyright:</strong> (c) 2025 <a href="https://abhinavsarkar.net">Abhinav Sarkar</a>, Google</p>
+<p>This is a <a href="https://en.wikipedia.org/wiki/JSON">JSON</a> parser written from scratch in <a href="https://www.haskell.org/">Haskell</a>
+in 183 lines. It complies with the JSON language specification set out in <a href="https://tools.ietf.org/html/rfc8259">IETF RFC 8259</a>,
+and passes the comprehensive <a href="https://github.com/nst/JSONTestSuite">JSON test suite</a>.</p>
+<p>It is a recursive-descent parser, written in <a href="https://en.wikipedia.org/wiki/Parser_combinator">Parser combinator</a>
+style.</p>
+<p>Compile it with <a href="https://www.haskell.org/ghc/">GHC</a> by running:</p>
+<pre><code class="language-shell">ghc --make *.hs -main-is JSONParser -o jsonparser
+</code></pre>
+<p>This parser has been extracted and simplified from Abhinav’s blog post
+<a href="https://abhinavsarkar.net/posts/json-parsing-from-scratch-in-haskell/">JSON Parsing from Scratch in Haskell</a>.</p>
+<hr>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-2">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-2">&#x00a7;</a>
+              </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-meta">{-# LANGUAGE TupleSections, LambdaCase #-}</span>
+<span class="hljs-keyword">module</span> JSONParser <span class="hljs-keyword">where</span>
+
+<span class="hljs-keyword">import</span> Control.Applicative (<span class="hljs-type">Alternative(..)</span>, <span class="hljs-title">optional</span>)
+<span class="hljs-keyword">import</span> Control.Monad (<span class="hljs-title">replicateM</span>)
+<span class="hljs-keyword">import</span> Data.Bits (<span class="hljs-title">shiftL</span>)
+<span class="hljs-keyword">import</span> Data.Char (<span class="hljs-title">isDigit</span>, <span class="hljs-title">isHexDigit</span>, <span class="hljs-title">chr</span>, <span class="hljs-title">ord</span>, <span class="hljs-title">digitToInt</span>)
+<span class="hljs-keyword">import</span> Data.Functor (($&gt;))
+<span class="hljs-keyword">import</span> System.Exit (<span class="hljs-title">exitFailure</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-3">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-3">&#x00a7;</a>
+              </div>
+              <p>The data type for representing a JSON value in Haskell.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">data</span> <span class="hljs-type">JValue</span> =</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-4">&#x00a7;</a>
+              </div>
+              <p>Null, a null value.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>              <span class="hljs-type">JNull</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-5">&#x00a7;</a>
+              </div>
+              <p>Boolean, a boolean value.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JBool</span> <span class="hljs-type">Bool</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-6">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-6">&#x00a7;</a>
+              </div>
+              <p>String, a string value, a sequence of zero or more Unicode characters.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JString</span> <span class="hljs-type">String</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-7">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-7">&#x00a7;</a>
+              </div>
+              <p>Number, a numeric value representing integral and real numbers with support for scientific notation.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JNumber</span> { int :: <span class="hljs-type">Integer</span>, frac :: [<span class="hljs-type">Int</span>], exponent :: <span class="hljs-type">Integer</span> }</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-8">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-8">&#x00a7;</a>
+              </div>
+              <p>Array, an ordered list of values.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JArray</span> [<span class="hljs-type">JValue</span>]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-9">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-9">&#x00a7;</a>
+              </div>
+              <p>Object, a collection of name-value pairs.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            | <span class="hljs-type">JObject</span> [(<span class="hljs-type">String</span>, <span class="hljs-type">JValue</span>)]
+            <span class="hljs-keyword">deriving</span> (<span class="hljs-type">Eq</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-10">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-10">&#x00a7;</a>
+              </div>
+              <p>A generic parser type. It takes some input <code>i</code>, reads some part of it, and optionally parses it into some
+relevant data structure <code>o</code> and the rest of the input <code>i</code> to be potentially parsed later. It may fail as well.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">newtype</span> <span class="hljs-type">Parser</span> i o =</span>
+  <span class="hljs-type">Parser</span> { runParser :: i -&gt; <span class="hljs-type">Maybe</span> (i, o) }</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-11">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-11">&#x00a7;</a>
+              </div>
+              <p>A <code>Parser</code> is a <a href="https://hackage.haskell.org/package/base/docs/Data-Functor.html#t:Functor"><code>Functor</code></a>.
+This allows us to modify the result of a parser without changing the structure of the result (a parse success stays
+a success, and a failure stays a failure).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">instance</span> <span class="hljs-type">Functor</span> (<span class="hljs-type">Parser</span> <span class="hljs-title">i</span>) <span class="hljs-keyword">where</span></span>
+  fmap f parser = <span class="hljs-type">Parser</span> $ fmap (fmap f) . runParser parser</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-12">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-12">&#x00a7;</a>
+              </div>
+              <p>A <code>Parser</code> is an <a href="https://hackage.haskell.org/package/base/docs/Control-Applicative.html#t:Applicative"><code>Applicative</code></a>.
+This allows us to combine the results of two parsers that are independent of each-other.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">instance</span> <span class="hljs-type">Applicative</span> (<span class="hljs-type">Parser</span> <span class="hljs-title">i</span>) <span class="hljs-keyword">where</span></span>
+  pure x    = <span class="hljs-type">Parser</span> $ pure . (, x)
+  pf &lt;*&gt; po = <span class="hljs-type">Parser</span> $ \input -&gt; <span class="hljs-keyword">case</span> runParser pf input <span class="hljs-keyword">of</span>
+    <span class="hljs-type">Nothing</span>        -&gt; <span class="hljs-type">Nothing</span>
+    <span class="hljs-type">Just</span> (rest, f) -&gt; fmap f &lt;$&gt; runParser po rest</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-13">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-13">&#x00a7;</a>
+              </div>
+              <p>A <code>Parser</code> is an <a href="https://hackage.haskell.org/package/base/docs/Control-Applicative.html#t:Alternative"><code>Alternative</code></a>.
+This allows us to fallback upon a second parser in case our first parser fails.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">instance</span> <span class="hljs-type">Alternative</span> (<span class="hljs-type">Parser</span> <span class="hljs-title">i</span>) <span class="hljs-keyword">where</span></span>
+  empty = <span class="hljs-type">Parser</span> $ const empty
+  p1 &lt;|&gt; p2 = <span class="hljs-type">Parser</span> $ \input -&gt; runParser p1 input &lt;|&gt; runParser p2 input</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-14">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-14">&#x00a7;</a>
+              </div>
+              <p>A <code>Parser</code> is <a href="https://hackage.haskell.org/package/base/docs/Control-Monad.html#t:Monad"><code>Monad</code></a>.
+This allows us to combine the results of two parsers sequentially, such that one parser is
+dependent on the result of other.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-class"><span class="hljs-keyword">instance</span> <span class="hljs-type">Monad</span> (<span class="hljs-type">Parser</span> <span class="hljs-title">i</span>) <span class="hljs-keyword">where</span></span>
+  p &gt;&gt;= f = <span class="hljs-type">Parser</span> $ \input -&gt; <span class="hljs-keyword">case</span> runParser p input <span class="hljs-keyword">of</span>
+    <span class="hljs-type">Nothing</span>        -&gt; <span class="hljs-type">Nothing</span>
+    <span class="hljs-type">Just</span> (rest, o) -&gt; runParser (f o) rest</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-15">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-15">&#x00a7;</a>
+              </div>
+              <p>A parser that succeeds if the first element of its input list matches the given predicate.
+Returns the matching element on success.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">satisfy</span> :: (a -&gt; <span class="hljs-type">Bool</span>) -&gt; <span class="hljs-type">Parser</span> [a] a
+<span class="hljs-title">satisfy</span> predicate = <span class="hljs-type">Parser</span> $ \<span class="hljs-keyword">case</span>
+  (x:xs) | predicate x -&gt; <span class="hljs-type">Just</span> (xs, x)
+  _                    -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-16">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-16">&#x00a7;</a>
+              </div>
+              <p>A parser that matches the first character of its input string with a given character.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">char</span> :: <span class="hljs-type">Char</span> -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">Char</span>
+<span class="hljs-title">char</span> c = satisfy (== c)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-17">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-17">&#x00a7;</a>
+              </div>
+              <p>A parser that succeeds if the first character of its input string is a digit (0–9).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">digit</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">Int</span>
+<span class="hljs-title">digit</span> = digitToInt &lt;$&gt; satisfy isDigit</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-18">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-18">&#x00a7;</a>
+              </div>
+              <p>A parser that matches its input string with a given string.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">string</span> :: <span class="hljs-type">String</span> -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">String</span>
+<span class="hljs-title">string</span> <span class="hljs-string">&quot;&quot;</span>     = pure <span class="hljs-string">&quot;&quot;</span>
+<span class="hljs-title">string</span> (c:cs) = (:) &lt;$&gt; char c &lt;*&gt; string cs</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-19">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-19">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON <code>null</code> value that matches the string “null”, and returns the <code>JNull</code> value on
+success.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jNull</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jNull</span> = string <span class="hljs-string">&quot;null&quot;</span> $&gt; <span class="hljs-type">JNull</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-20">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-20">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON boolean values that matches the strings “true” or “false”, and returns the
+corresponding <code>JBool</code> value on success.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jBool</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jBool</span> =   string <span class="hljs-string">&quot;true&quot;</span>  $&gt; <span class="hljs-type">JBool</span> <span class="hljs-type">True</span>
+      &lt;|&gt; string <span class="hljs-string">&quot;false&quot;</span> $&gt; <span class="hljs-type">JBool</span> <span class="hljs-type">False</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-21">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-21">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON characters that matches ASCII characters, as well as, escaped sequences
+for characters defined in the JSON spec, and Unicode characters with <code>\u</code> prefix and their hex-digit codes.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jsonChar</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">Char</span>
+<span class="hljs-title">jsonChar</span> =   string <span class="hljs-string">&quot;\\\&quot;&quot;</span> $&gt; <span class="hljs-string">&#x27;&quot;&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\\\&quot;</span> $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\/&quot;</span>  $&gt; <span class="hljs-string">&#x27;/&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\b&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\b</span>&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\f&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\f</span>&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\n&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\n</span>&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\r&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\r</span>&#x27;</span>
+         &lt;|&gt; string <span class="hljs-string">&quot;\\t&quot;</span>  $&gt; <span class="hljs-string">&#x27;<span class="hljs-char escape_">\t</span>&#x27;</span>
+         &lt;|&gt; unicodeChar
+         &lt;|&gt; satisfy (\c -&gt; not (c == <span class="hljs-string">&#x27;<span class="hljs-char escape_">\&quot;</span>&#x27;</span> || c == <span class="hljs-string">&#x27;<span class="hljs-char escape_">\\</span>&#x27;</span> || isControl c))
+  <span class="hljs-keyword">where</span>
+    unicodeChar =
+      chr . fromIntegral . digitsToNumber <span class="hljs-number">16</span> <span class="hljs-number">0</span>
+        &lt;$&gt; (string <span class="hljs-string">&quot;\\u&quot;</span> *&gt; replicateM <span class="hljs-number">4</span> hexDigit)
+
+    hexDigit = digitToInt &lt;$&gt; satisfy isHexDigit
+
+    isControl c = c `elem` [<span class="hljs-string">&#x27;<span class="hljs-char escape_">\0</span>&#x27;</span> .. &#x27;\<span class="hljs-number">31</span>&#x27;]
+
+<span class="hljs-title">digitsToNumber</span> :: <span class="hljs-type">Int</span> -&gt; <span class="hljs-type">Integer</span> -&gt; [<span class="hljs-type">Int</span>] -&gt; <span class="hljs-type">Integer</span>
+<span class="hljs-title">digitsToNumber</span> base =
+  foldl (\num d -&gt; num * fromIntegral base + fromIntegral d)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-22">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-22">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON strings that takes care of correctly parsing <a href="https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF">UTF-16 surrogate pairs</a>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jString</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jString</span> = <span class="hljs-type">JString</span> &lt;$&gt; (char <span class="hljs-string">&#x27;&quot;&#x27;</span> *&gt; jString&#x27;)
+  <span class="hljs-keyword">where</span>
+    jString&#x27; = <span class="hljs-keyword">do</span>
+      optFirst &lt;- optional jsonChar
+      <span class="hljs-keyword">case</span> optFirst <span class="hljs-keyword">of</span>
+        <span class="hljs-type">Nothing</span> -&gt; <span class="hljs-string">&quot;&quot;</span> &lt;$ char <span class="hljs-string">&#x27;&quot;&#x27;</span>
+        <span class="hljs-type">Just</span> first | not (isSurrogate first) -&gt;
+          (first:) &lt;$&gt; jString&#x27;
+        <span class="hljs-type">Just</span> first -&gt; <span class="hljs-keyword">do</span>
+          second &lt;- jsonChar
+          <span class="hljs-keyword">if</span> isHighSurrogate first &amp;&amp; isLowSurrogate second
+          <span class="hljs-keyword">then</span> (combineSurrogates first second :) &lt;$&gt; jString&#x27;
+          <span class="hljs-keyword">else</span> empty
+
+    isHighSurrogate a =
+      ord a &gt;= highSurrogateLowerBound &amp;&amp; ord a &lt;= highSurrogateUpperBound
+    isLowSurrogate a  =
+      ord a &gt;= lowSurrogateLowerBound &amp;&amp; ord a &lt;= lowSurrogateUpperBound
+    isSurrogate a     = isHighSurrogate a || isLowSurrogate a
+
+    combineSurrogates a b = chr $
+      ((ord a - highSurrogateLowerBound) `shiftL` <span class="hljs-number">10</span>)
+      + (ord b - lowSurrogateLowerBound) + <span class="hljs-number">0x10000</span>
+
+    highSurrogateLowerBound = <span class="hljs-number">0xD800</span>
+    highSurrogateUpperBound = <span class="hljs-number">0xDBFF</span>
+    lowSurrogateLowerBound  = <span class="hljs-number">0xDC00</span>
+    lowSurrogateUpperBound  = <span class="hljs-number">0xDFFF</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-23">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-23">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON numbers in integer, decimal or scientific notation formats.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jNumber</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jNumber</span> = jIntFracExp &lt;|&gt; jIntExp &lt;|&gt; jIntFrac &lt;|&gt; jInt
+  <span class="hljs-keyword">where</span>
+    jInt = <span class="hljs-type">JNumber</span> &lt;$&gt; jInt&#x27; &lt;*&gt; pure [] &lt;*&gt; pure <span class="hljs-number">0</span>
+    jIntExp = <span class="hljs-type">JNumber</span> &lt;$&gt; jInt&#x27; &lt;*&gt; pure [] &lt;*&gt; jExp
+    jIntFrac = (\i f -&gt; <span class="hljs-type">JNumber</span> i f <span class="hljs-number">0</span>) &lt;$&gt; jInt&#x27; &lt;*&gt; jFrac
+    jIntFracExp = (\ ~(<span class="hljs-type">JNumber</span> i f _) e -&gt; <span class="hljs-type">JNumber</span> i f e) &lt;$&gt; jIntFrac &lt;*&gt; jExp
+
+    jInt&#x27; = signInt &lt;$&gt; optional (char <span class="hljs-string">&#x27;-&#x27;</span>) &lt;*&gt; jUInt
+    jUInt =   (\d ds -&gt; digitsToNumber <span class="hljs-number">10</span> <span class="hljs-number">0</span> (d:ds)) &lt;$&gt; digit19 &lt;*&gt; digits
+          &lt;|&gt; fromIntegral &lt;$&gt; digit
+
+    jFrac = char <span class="hljs-string">&#x27;.&#x27;</span> *&gt; digits
+    jExp = (char <span class="hljs-string">&#x27;e&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;E&#x27;</span>)
+      *&gt; (signInt &lt;$&gt; optional (char <span class="hljs-string">&#x27;+&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;-&#x27;</span>) &lt;*&gt; jUInt)
+
+    digit19 = digitToInt &lt;$&gt; satisfy (\x -&gt; isDigit x &amp;&amp; x /= <span class="hljs-string">&#x27;0&#x27;</span>)
+    digits = some digit
+
+    signInt (<span class="hljs-type">Just</span> <span class="hljs-string">&#x27;-&#x27;</span>) i = negate i
+    signInt _          i = i
+
+<span class="hljs-title">surroundedBy</span> ::
+  <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> a -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> b -&gt; <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> a
+<span class="hljs-title">surroundedBy</span> p1 p2 = p2 *&gt; p1 &lt;* p2
+
+<span class="hljs-title">separatedBy</span> :: <span class="hljs-type">Parser</span> i v -&gt; <span class="hljs-type">Parser</span> i s -&gt; <span class="hljs-type">Parser</span> i [v]
+<span class="hljs-title">separatedBy</span> v s =   (:) &lt;$&gt; v &lt;*&gt; many (s *&gt; v)
+                &lt;|&gt; pure []
+
+<span class="hljs-title">spaces</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">String</span>
+<span class="hljs-title">spaces</span> = many (char <span class="hljs-string">&#x27; &#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\n</span>&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\r</span>&#x27;</span> &lt;|&gt; char <span class="hljs-string">&#x27;<span class="hljs-char escape_">\t</span>&#x27;</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-24">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-24">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON arrays, containing zero or more items of any JSON types separated by commas.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jArray</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jArray</span> = <span class="hljs-type">JArray</span> &lt;$&gt;
+  (char <span class="hljs-string">&#x27;[&#x27;</span>
+   *&gt; (jValue `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces)
+   &lt;* char <span class="hljs-string">&#x27;]&#x27;</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-25">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-25">&#x00a7;</a>
+              </div>
+              <p>The parser for JSON objects, containing  zero or more key-value pairs separated by colon, where
+keys are JSON strings, and values are any JSON types.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jObject</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jObject</span> = <span class="hljs-type">JObject</span> &lt;$&gt;
+  (char <span class="hljs-string">&#x27;{&#x27;</span> *&gt; pair `separatedBy` char <span class="hljs-string">&#x27;,&#x27;</span> `surroundedBy` spaces &lt;* char <span class="hljs-string">&#x27;}&#x27;</span>)
+  <span class="hljs-keyword">where</span>
+    pair = (\ ~(<span class="hljs-type">JString</span> s) j -&gt; (s, j))
+      &lt;$&gt; (jString `surroundedBy` spaces)
+      &lt;*  char <span class="hljs-string">&#x27;:&#x27;</span>
+      &lt;*&gt; jValue</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-26">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-26">&#x00a7;</a>
+              </div>
+              <p>The parser for any JSON value, created by combining all the previous JSON parsers.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">jValue</span> :: <span class="hljs-type">Parser</span> <span class="hljs-type">String</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">jValue</span> = jValue&#x27; `surroundedBy` spaces
+  <span class="hljs-keyword">where</span>
+    jValue&#x27; =   jNull
+            &lt;|&gt; jBool
+            &lt;|&gt; jString
+            &lt;|&gt; jNumber
+            &lt;|&gt; jArray
+            &lt;|&gt; jObject</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-27">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-27">&#x00a7;</a>
+              </div>
+              <p><code>parseJSON</code> parses its input string as a JSON value, or fails on parsing errors.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">parseJSON</span> :: <span class="hljs-type">String</span> -&gt; <span class="hljs-type">Maybe</span> <span class="hljs-type">JValue</span>
+<span class="hljs-title">parseJSON</span> s = <span class="hljs-keyword">case</span> runParser jValue s <span class="hljs-keyword">of</span>
+  <span class="hljs-type">Just</span> (<span class="hljs-string">&quot;&quot;</span>, j) -&gt; <span class="hljs-type">Just</span> j
+  _            -&gt; <span class="hljs-type">Nothing</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-28">
+            <div class="annotation">
+              
+              <div class="sswrap ">
+                <a class="ss" href="#section-28">&#x00a7;</a>
+              </div>
+              <p><code>main</code> function reads text from standard input, and parses it as a JSON value.
+Prints a message indicating whether parsing succeeded or failed.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-title">main</span> :: <span class="hljs-type">IO</span> ()
+<span class="hljs-title">main</span> = getContents &gt;&gt;= \input -&gt; <span class="hljs-keyword">case</span> parseJSON input <span class="hljs-keyword">of</span>
+  <span class="hljs-type">Just</span> _ -&gt; putStrLn <span class="hljs-string">&quot;Parse okay&quot;</span>
+  <span class="hljs-type">Nothing</span> -&gt; putStrLn <span class="hljs-string">&quot;Parse failed&quot;</span> &gt;&gt; exitFailure</pre></div></div>
+            
+        </li>
+        
+    </ul>
+  </div>
+</body>
+</html>

--- a/docs/just-in-time/index.html
+++ b/docs/just-in-time/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../json-parser/index.html">
+                  ./json-parser/index.hs
+                </a>
+              
+                
                 <a class="source" href="index.html">
                   ./just-in-time/index.py
                 </a>
@@ -154,7 +159,7 @@ hence vary at runtime, so we keep relocations in the <code>rels</code> array for
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">dot</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-built_in">int</span>:
-        <span class="hljs-keyword">return</span> <span class="hljs-built_in">len</span>(self.ops)</pre></div></div>
+        <span class="hljs-keyword">return</span> <span class="hljs-built_in">len</span>(<span class="hljs-variable language_">self</span>.ops)</pre></div></div>
             
         </li>
         
@@ -171,7 +176,7 @@ in lieu of a more powerful assembler</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">db</span>(<span class="hljs-params">self, v: <span class="hljs-type">List</span>[<span class="hljs-built_in">int</span>]</span>):
-        self.ops.extend(v)</pre></div></div>
+        <span class="hljs-variable language_">self</span>.ops.extend(v)</pre></div></div>
             
         </li>
         
@@ -188,7 +193,7 @@ in lieu of a more powerful assembler</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">dd</span>(<span class="hljs-params">self, v: <span class="hljs-built_in">int</span></span>):
-        self.db([(v&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">4</span>)])</pre></div></div>
+        <span class="hljs-variable language_">self</span>.db([(v&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">4</span>)])</pre></div></div>
             
         </li>
         
@@ -205,7 +210,7 @@ in lieu of a more powerful assembler</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">dq</span>(<span class="hljs-params">self, v: <span class="hljs-built_in">int</span></span>):
-        self.db([(v&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">8</span>)])</pre></div></div>
+        <span class="hljs-variable language_">self</span>.db([(v&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">8</span>)])</pre></div></div>
             
         </li>
         
@@ -222,8 +227,8 @@ opcode data which must be fixed up at load time</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">reloc</span>(<span class="hljs-params">self, dst: <span class="hljs-built_in">int</span></span>):
-        self.rels.append((self.dot(), dst))
-        self.dd(<span class="hljs-number">0</span>)</pre></div></div>
+        <span class="hljs-variable language_">self</span>.rels.append((<span class="hljs-variable language_">self</span>.dot(), dst))
+        <span class="hljs-variable language_">self</span>.dd(<span class="hljs-number">0</span>)</pre></div></div>
             
         </li>
         
@@ -617,9 +622,9 @@ The address of our executable page is <code>adr</code> and it extends <code>len<
             
             <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> name != <span class="hljs-string">&#x27;posix&#x27;</span> <span class="hljs-keyword">or</span> maxsize != <span class="hljs-number">2</span>**<span class="hljs-number">63</span>-<span class="hljs-number">1</span> <span class="hljs-keyword">or</span> (<span class="hljs-keyword">not</span>
            <span class="hljs-built_in">any</span>(<span class="hljs-string">&quot;86&quot;</span> <span class="hljs-keyword">in</span> f <span class="hljs-keyword">for</span> f <span class="hljs-keyword">in</span> [processor(),machine()])):
-            self.<span class="hljs-built_in">len</span>   = <span class="hljs-number">0</span>
-            self.adr   = <span class="hljs-number">0</span>
-            self.valid = <span class="hljs-literal">False</span>
+            <span class="hljs-variable language_">self</span>.<span class="hljs-built_in">len</span>   = <span class="hljs-number">0</span>
+            <span class="hljs-variable language_">self</span>.adr   = <span class="hljs-number">0</span>
+            <span class="hljs-variable language_">self</span>.valid = <span class="hljs-literal">False</span>
         <span class="hljs-keyword">else</span>:</pre></div></div>
             
         </li>
@@ -656,9 +661,9 @@ The address of our executable page is <code>adr</code> and it extends <code>len<
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>            self.<span class="hljs-built_in">len</span>   = pythonapi.getpagesize()
-            self.adr   = pythonapi.mmap(<span class="hljs-number">0</span>, self.<span class="hljs-built_in">len</span>, <span class="hljs-number">7</span>, <span class="hljs-number">0x1022</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">0</span>)
-            self.valid = <span class="hljs-literal">True</span></pre></div></div>
+            <div class="content"><div class='highlight'><pre>            <span class="hljs-variable language_">self</span>.<span class="hljs-built_in">len</span>   = pythonapi.getpagesize()
+            <span class="hljs-variable language_">self</span>.adr   = pythonapi.mmap(<span class="hljs-number">0</span>, <span class="hljs-variable language_">self</span>.<span class="hljs-built_in">len</span>, <span class="hljs-number">7</span>, <span class="hljs-number">0x1022</span>, -<span class="hljs-number">1</span>, <span class="hljs-number">0</span>)
+            <span class="hljs-variable language_">self</span>.valid = <span class="hljs-literal">True</span></pre></div></div>
             
         </li>
         
@@ -689,7 +694,7 @@ offsets between our calls and their referents</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        adr = self.adr+off
+            <div class="content"><div class='highlight'><pre>        adr = <span class="hljs-variable language_">self</span>.adr+off
         rel = dst - (adr+<span class="hljs-number">4</span>)
         buf = cast(adr, POINTER(c_char*<span class="hljs-number">4</span>)).contents
         buf[:] = [(rel&gt;&gt;<span class="hljs-number">8</span>*i)&amp;<span class="hljs-number">0xff</span> <span class="hljs-keyword">for</span> i <span class="hljs-keyword">in</span> <span class="hljs-built_in">range</span>(<span class="hljs-number">4</span>)]</pre></div></div>
@@ -709,9 +714,9 @@ returning a function pointer to the start of the assembly.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">load</span>(<span class="hljs-params">self, a:Asm</span>) -&gt; Thunk:
-        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> self.valid:
+        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> <span class="hljs-variable language_">self</span>.valid:
             <span class="hljs-keyword">raise</span> JitError(<span class="hljs-string">&quot;couldn&#x27;t confirm posix x86-64&quot;</span>)
-        <span class="hljs-keyword">if</span> a.dot() &gt; self.<span class="hljs-built_in">len</span>:
+        <span class="hljs-keyword">if</span> a.dot() &gt; <span class="hljs-variable language_">self</span>.<span class="hljs-built_in">len</span>:
             <span class="hljs-keyword">raise</span> JitError(<span class="hljs-string">&quot;too complex&quot;</span>)</pre></div></div>
             
         </li>
@@ -727,7 +732,7 @@ returning a function pointer to the start of the assembly.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        pythonapi.memset(self.adr, <span class="hljs-number">0xcc</span>, self.<span class="hljs-built_in">len</span>)</pre></div></div>
+            <div class="content"><div class='highlight'><pre>        pythonapi.memset(<span class="hljs-variable language_">self</span>.adr, <span class="hljs-number">0xcc</span>, <span class="hljs-variable language_">self</span>.<span class="hljs-built_in">len</span>)</pre></div></div>
             
         </li>
         
@@ -742,7 +747,7 @@ returning a function pointer to the start of the assembly.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>        pythonapi.memcpy(self.adr, <span class="hljs-built_in">bytes</span>(a.ops), a.dot())</pre></div></div>
+            <div class="content"><div class='highlight'><pre>        pythonapi.memcpy(<span class="hljs-variable language_">self</span>.adr, <span class="hljs-built_in">bytes</span>(a.ops), a.dot())</pre></div></div>
             
         </li>
         
@@ -758,8 +763,8 @@ returning a function pointer to the start of the assembly.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">for</span> off,dst <span class="hljs-keyword">in</span> a.rels:
-            self.fixup(off,dst)
-        <span class="hljs-keyword">return</span> Thunk(self.adr)</pre></div></div>
+            <span class="hljs-variable language_">self</span>.fixup(off,dst)
+        <span class="hljs-keyword">return</span> Thunk(<span class="hljs-variable language_">self</span>.adr)</pre></div></div>
             
         </li>
         
@@ -775,7 +780,7 @@ returning a function pointer to the start of the assembly.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">def</span> <span class="hljs-title function_">eval</span>(<span class="hljs-params">self, expr</span>) -&gt; <span class="hljs-built_in">int</span>:
-        thunk = self.load(codegen(Asm(), expr))
+        thunk = <span class="hljs-variable language_">self</span>.load(codegen(Asm(), expr))
         <span class="hljs-keyword">return</span> thunk()</pre></div></div>
             
         </li>
@@ -807,7 +812,7 @@ returning a function pointer to the start of the assembly.</p>
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">SmokeTests</span>(unittest.TestCase):
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">setUp</span>(<span class="hljs-params">self</span>):
-        self.j = JitPage()
+        <span class="hljs-variable language_">self</span>.j = JitPage()
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_expressions</span>(<span class="hljs-params">self</span>):
         tests = [
@@ -825,18 +830,18 @@ returning a function pointer to the start of the assembly.</p>
         ([<span class="hljs-string">&#x27;add&#x27;</span>,<span class="hljs-number">1</span>,[<span class="hljs-string">&#x27;mul&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-number">3</span>]],<span class="hljs-number">7</span>),
         ]
         <span class="hljs-keyword">for</span> xpr,res <span class="hljs-keyword">in</span> tests:
-            <span class="hljs-keyword">with</span> self.subTest(xpr=xpr,res=res):
-                self.assertEqual(self.j.<span class="hljs-built_in">eval</span>(xpr),res)
+            <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.subTest(xpr=xpr,res=res):
+                <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.j.<span class="hljs-built_in">eval</span>(xpr),res)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_string_literal</span>(<span class="hljs-params">self</span>):
-        <span class="hljs-keyword">with</span> self.assertRaisesRegex(JitError, <span class="hljs-string">&quot;unimplemented literal&quot;</span>):
-            self.j.<span class="hljs-built_in">eval</span>([<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-string">&#x27;dozen&#x27;</span>])
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assertRaisesRegex(JitError, <span class="hljs-string">&quot;unimplemented literal&quot;</span>):
+            <span class="hljs-variable language_">self</span>.j.<span class="hljs-built_in">eval</span>([<span class="hljs-string">&#x27;*&#x27;</span>,<span class="hljs-number">2</span>,<span class="hljs-string">&#x27;dozen&#x27;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_too_complex</span>(<span class="hljs-params">self</span>):
         <span class="hljs-keyword">def</span> <span class="hljs-title function_">sumtree</span>(<span class="hljs-params">d</span>):
             <span class="hljs-keyword">return</span> <span class="hljs-number">1</span> <span class="hljs-keyword">if</span> d==<span class="hljs-number">0</span> <span class="hljs-keyword">else</span> [<span class="hljs-string">&#x27;+&#x27;</span>,sumtree(d-<span class="hljs-number">1</span>),sumtree(d-<span class="hljs-number">1</span>)]
-        <span class="hljs-keyword">with</span> self.assertRaisesRegex(JitError, <span class="hljs-string">&quot;too complex&quot;</span>):
-            self.j.<span class="hljs-built_in">eval</span>(sumtree(<span class="hljs-number">9</span>))
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assertRaisesRegex(JitError, <span class="hljs-string">&quot;too complex&quot;</span>):
+            <span class="hljs-variable language_">self</span>.j.<span class="hljs-built_in">eval</span>(sumtree(<span class="hljs-number">9</span>))
 
 <span class="hljs-keyword">if</span> __name__ == <span class="hljs-string">&quot;__main__&quot;</span>:
     unittest.main()</pre></div></div>

--- a/docs/packrat-parsing/index.html
+++ b/docs/packrat-parsing/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../json-parser/index.html">
+                  ./json-parser/index.hs
+                </a>
+              
+                
                 <a class="source" href="../just-in-time/index.html">
                   ./just-in-time/index.py
                 </a>

--- a/docs/precedence-climbing/index.html
+++ b/docs/precedence-climbing/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../json-parser/index.html">
+                  ./json-parser/index.hs
+                </a>
+              
+                
                 <a class="source" href="../just-in-time/index.html">
                   ./just-in-time/index.py
                 </a>
@@ -652,159 +657,159 @@ lines but are illustrative.</p>
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">TokenizerTests</span>(unittest.TestCase):
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_empty</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;&quot;</span>), [])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;&quot;</span>), [])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_digit</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;1&quot;</span>), [<span class="hljs-number">1</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;1&quot;</span>), [<span class="hljs-number">1</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_number</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;123&quot;</span>), [<span class="hljs-number">123</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;123&quot;</span>), [<span class="hljs-number">123</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;+&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;+&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_sub</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;-&quot;</span>), [<span class="hljs-string">&quot;-&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;-&quot;</span>), [<span class="hljs-string">&quot;-&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_sub</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;-&quot;</span>), [<span class="hljs-string">&quot;-&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;-&quot;</span>), [<span class="hljs-string">&quot;-&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_mul</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;*&quot;</span>), [<span class="hljs-string">&quot;*&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;*&quot;</span>), [<span class="hljs-string">&quot;*&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_div</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;/&quot;</span>), [<span class="hljs-string">&quot;/&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;/&quot;</span>), [<span class="hljs-string">&quot;/&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_pow</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;^&quot;</span>), [<span class="hljs-string">&quot;^&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;^&quot;</span>), [<span class="hljs-string">&quot;^&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_comma</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;,&quot;</span>), [<span class="hljs-string">&quot;,&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;,&quot;</span>), [<span class="hljs-string">&quot;,&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_less</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;&lt;&quot;</span>), [<span class="hljs-string">&quot;&lt;&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;&lt;&quot;</span>), [<span class="hljs-string">&quot;&lt;&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_less_than_one</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;&lt;1&quot;</span>), [<span class="hljs-string">&quot;&lt;&quot;</span>, <span class="hljs-number">1</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;&lt;1&quot;</span>), [<span class="hljs-string">&quot;&lt;&quot;</span>, <span class="hljs-number">1</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_less_equal_one</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;&lt;=1&quot;</span>), [<span class="hljs-string">&quot;&lt;=&quot;</span>, <span class="hljs-number">1</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;&lt;=1&quot;</span>), [<span class="hljs-string">&quot;&lt;=&quot;</span>, <span class="hljs-number">1</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_skip_whitespace</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;1         2&quot;</span>), [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;1         2&quot;</span>), [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_skip_line_comment</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;1#         2\n3&quot;</span>), [<span class="hljs-number">1</span>, <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;1#         2\n3&quot;</span>), [<span class="hljs-number">1</span>, <span class="hljs-number">3</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_unrecognized_operator</span>(<span class="hljs-params">self</span>):
-        <span class="hljs-keyword">with</span> self.assertRaises(ParseError):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assertRaises(ParseError):
             tokenize(<span class="hljs-string">&quot;%&quot;</span>)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_var</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;a&quot;</span>), [<span class="hljs-string">&quot;a&quot;</span>])
-        self.assertEqual(tokenize(<span class="hljs-string">&quot;abc&quot;</span>), [<span class="hljs-string">&quot;abc&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;a&quot;</span>), [<span class="hljs-string">&quot;a&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(tokenize(<span class="hljs-string">&quot;abc&quot;</span>), [<span class="hljs-string">&quot;abc&quot;</span>])
 
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">ParseTests</span>(unittest.TestCase):
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">assert_parse_error</span>(<span class="hljs-params">self, message</span>):
-        <span class="hljs-keyword">return</span> self.assertRaisesRegex(ParseError, re.escape(message))
+        <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>.assertRaisesRegex(ParseError, re.escape(message))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_empty</span>(<span class="hljs-params">self</span>):
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected end of input&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected end of input&quot;</span>):
             parse([])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_const</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">3</span>]), <span class="hljs-number">3</span>)
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">3</span>]), <span class="hljs-number">3</span>)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_var</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-string">&quot;abc&quot;</span>]), <span class="hljs-string">&quot;abc&quot;</span>)
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;abc&quot;</span>]), <span class="hljs-string">&quot;abc&quot;</span>)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_const_leftover_raises</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected tokens: 4 5&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected tokens: 4 5&quot;</span>):
             parse([<span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_const_paren</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-string">&quot;)&quot;</span>]), <span class="hljs-number">3</span>)
-        self.assertEqual(parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-string">&quot;)&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), <span class="hljs-number">3</span>)
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-string">&quot;)&quot;</span>]), <span class="hljs-number">3</span>)
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-string">&quot;)&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), <span class="hljs-number">3</span>)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_const_paren_missing</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis&quot;</span>):
             parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">3</span>])
 
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected tokens: )&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected tokens: )&quot;</span>):
             parse([<span class="hljs-number">3</span>, <span class="hljs-string">&quot;)&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_fun</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_fun_no_arguments</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), [<span class="hljs-string">&quot;f&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), [<span class="hljs-string">&quot;f&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_fun_missing_closing_paren</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis in function call&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis in function call&quot;</span>):
             parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>])
 
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis in function call&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis in function call&quot;</span>):
             parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_fun_need_comma</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis in function call&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Expected closing parenthesis in function call&quot;</span>):
             parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_fun_double_comma</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected token: ,&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected token: ,&quot;</span>):
             parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;,&quot;</span>, <span class="hljs-string">&quot;,&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_fun_more_than_one_argument</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;,&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;,&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>, <span class="hljs-string">&quot;)&quot;</span>]), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_negate_const</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected end of input&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected end of input&quot;</span>):
             parse([<span class="hljs-string">&quot;-&quot;</span>])
-        self.assertEqual(parse([<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">3</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add_negate</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">2</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">2</span>]])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_mul_negate</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">2</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">2</span>]])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_sub_negate</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">2</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;negate&quot;</span>, <span class="hljs-number">2</span>]])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_begin_add_raises</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected operator: +&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected operator: +&quot;</span>):
             parse([<span class="hljs-string">&quot;+&quot;</span>])
 
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected operator: +&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected operator: +&quot;</span>):
             parse([<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_double_add_raises</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        <span class="hljs-keyword">with</span> self.assert_parse_error(<span class="hljs-string">&quot;Unexpected operator: +&quot;</span>):
+        <span class="hljs-keyword">with</span> <span class="hljs-variable language_">self</span>.assert_parse_error(<span class="hljs-string">&quot;Unexpected operator: +&quot;</span>):
             parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add_add</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add_mul</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]])
-        self.assertEqual(parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;)&quot;</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;*&quot;</span>, [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-string">&quot;(&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;)&quot;</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;*&quot;</span>, [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_mul_add</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_sub</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>]), [<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_sub_sub</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;-&quot;</span>, [<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;-&quot;</span>, [<span class="hljs-string">&quot;-&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add_mul</span>(<span class="hljs-params">self</span>) -&gt; <span class="hljs-literal">None</span>:
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]])
-        self.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(parse([<span class="hljs-number">1</span>, <span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">2</span>, <span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>]), [<span class="hljs-string">&quot;+&quot;</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>])
 
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">EndToEndTests</span>(unittest.TestCase):
@@ -812,35 +817,35 @@ lines but are illustrative.</p>
         <span class="hljs-keyword">return</span> parse(tokenize(source))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_int</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;123&quot;</span>), <span class="hljs-number">123</span>)
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;123&quot;</span>), <span class="hljs-number">123</span>)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;3+4&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;3+4&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_add_call</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;1+f(2)*3&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;*&quot;</span>, [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>]])
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;1*f(2)+3&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-number">2</span>]], <span class="hljs-number">3</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;1+f(2)*3&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;*&quot;</span>, [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-number">2</span>], <span class="hljs-number">3</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;1*f(2)+3&quot;</span>), [<span class="hljs-string">&quot;+&quot;</span>, [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">1</span>, [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-number">2</span>]], <span class="hljs-number">3</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_call</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f(1)(2)&quot;</span>), [[<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-number">1</span>], <span class="hljs-number">2</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f(1)(2)&quot;</span>), [[<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-number">1</span>], <span class="hljs-number">2</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call0</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f()&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f()&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call1</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f(x)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f(x)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call2</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f(x, y)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f(x, y)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call3</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f(x, y, z)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>, <span class="hljs-string">&quot;z&quot;</span>])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f(x, y, z)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>, <span class="hljs-string">&quot;z&quot;</span>])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_expression_argument</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f(1+2, 3*4)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f(1+2, 3*4)&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, [<span class="hljs-string">&quot;+&quot;</span>, <span class="hljs-number">1</span>, <span class="hljs-number">2</span>], [<span class="hljs-string">&quot;*&quot;</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>]])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">test_call_nested</span>(<span class="hljs-params">self</span>):
-        self.assertEqual(self.parse(<span class="hljs-string">&quot;f(g(x), h(y))&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, [<span class="hljs-string">&quot;g&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>], [<span class="hljs-string">&quot;h&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>]])
+        <span class="hljs-variable language_">self</span>.assertEqual(<span class="hljs-variable language_">self</span>.parse(<span class="hljs-string">&quot;f(g(x), h(y))&quot;</span>), [<span class="hljs-string">&quot;f&quot;</span>, [<span class="hljs-string">&quot;g&quot;</span>, <span class="hljs-string">&quot;x&quot;</span>], [<span class="hljs-string">&quot;h&quot;</span>, <span class="hljs-string">&quot;y&quot;</span>]])
 
 
 <span class="hljs-keyword">if</span> __name__ == <span class="hljs-string">&quot;__main__&quot;</span>:

--- a/docs/relational-db/index.html
+++ b/docs/relational-db/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../json-parser/index.html">
+                  ./json-parser/index.hs
+                </a>
+              
+                
                 <a class="source" href="../just-in-time/index.html">
                   ./just-in-time/index.py
                 </a>
@@ -71,49 +76,49 @@ to Python.</p>
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">Table</span>:
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self, name: <span class="hljs-built_in">str</span>, rows: <span class="hljs-built_in">tuple</span>[<span class="hljs-built_in">dict</span>] = (<span class="hljs-params"></span>)</span>):
-        self.name = name
-        self.rows = <span class="hljs-built_in">tuple</span>(rows)
-        self._colnames = ()
+        <span class="hljs-variable language_">self</span>.name = name
+        <span class="hljs-variable language_">self</span>.rows = <span class="hljs-built_in">tuple</span>(rows)
+        <span class="hljs-variable language_">self</span>._colnames = ()
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">set_colnames</span>(<span class="hljs-params">self, colnames</span>):
-        self._colnames = <span class="hljs-built_in">tuple</span>(<span class="hljs-built_in">sorted</span>(colnames))
+        <span class="hljs-variable language_">self</span>._colnames = <span class="hljs-built_in">tuple</span>(<span class="hljs-built_in">sorted</span>(colnames))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">colnames</span>(<span class="hljs-params">self</span>):
-        <span class="hljs-keyword">if</span> self._colnames:
-            <span class="hljs-keyword">return</span> self._colnames
-        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> self.rows:
+        <span class="hljs-keyword">if</span> <span class="hljs-variable language_">self</span>._colnames:
+            <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>._colnames
+        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> <span class="hljs-variable language_">self</span>.rows:
             <span class="hljs-keyword">raise</span> ValueError(<span class="hljs-string">&quot;Need either rows or manually specified column names&quot;</span>)
-        <span class="hljs-keyword">return</span> <span class="hljs-built_in">tuple</span>(<span class="hljs-built_in">sorted</span>(self.rows[<span class="hljs-number">0</span>].keys()))
+        <span class="hljs-keyword">return</span> <span class="hljs-built_in">tuple</span>(<span class="hljs-built_in">sorted</span>(<span class="hljs-variable language_">self</span>.rows[<span class="hljs-number">0</span>].keys()))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">filter</span>(<span class="hljs-params">self, pred</span>):
-        <span class="hljs-keyword">return</span> Table(self.name, [row <span class="hljs-keyword">for</span> row <span class="hljs-keyword">in</span> self.rows <span class="hljs-keyword">if</span> pred(row)])
+        <span class="hljs-keyword">return</span> Table(<span class="hljs-variable language_">self</span>.name, [row <span class="hljs-keyword">for</span> row <span class="hljs-keyword">in</span> <span class="hljs-variable language_">self</span>.rows <span class="hljs-keyword">if</span> pred(row)])
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">__repr__</span>(<span class="hljs-params">self</span>):
-        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> self.name:
+        <span class="hljs-keyword">if</span> <span class="hljs-keyword">not</span> <span class="hljs-variable language_">self</span>.name:
             <span class="hljs-keyword">return</span> <span class="hljs-string">f&quot;Table(<span class="hljs-subst">{<span class="hljs-built_in">list</span>(self.rows)!r}</span>)&quot;</span>
         <span class="hljs-keyword">return</span> <span class="hljs-string">f&quot;Table(<span class="hljs-subst">{self.name!r}</span>, <span class="hljs-subst">{<span class="hljs-built_in">list</span>(self.rows)!r}</span>)&quot;</span>
 
 
 <span class="hljs-keyword">class</span> <span class="hljs-title class_">Database</span>:
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">__init__</span>(<span class="hljs-params">self</span>):
-        self.tables = {}
+        <span class="hljs-variable language_">self</span>.tables = {}
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">CREATE_TABLE</span>(<span class="hljs-params">self, name, colnames=(<span class="hljs-params"></span>)</span>):
         table = Table(name)
         <span class="hljs-keyword">if</span> colnames:
             table.set_colnames(colnames)
-        self.tables[name] = table
+        <span class="hljs-variable language_">self</span>.tables[name] = table
         <span class="hljs-keyword">return</span> table
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">DROP_TABLE</span>(<span class="hljs-params">self, name</span>):
-        <span class="hljs-keyword">del</span> self.tables[name]
+        <span class="hljs-keyword">del</span> <span class="hljs-variable language_">self</span>.tables[name]
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">FROM</span>(<span class="hljs-params">self, first_table, *rest</span>):
-        match rest:
-            case ():
-                <span class="hljs-keyword">return</span> self.tables[first_table]
-            case _:
-                <span class="hljs-keyword">return</span> self.CROSS_JOIN(self.tables[first_table], self.FROM(*rest))
+        <span class="hljs-keyword">match</span> rest:
+            <span class="hljs-keyword">case</span> ():
+                <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>.tables[first_table]
+            <span class="hljs-keyword">case</span> _:
+                <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>.CROSS_JOIN(<span class="hljs-variable language_">self</span>.tables[first_table], <span class="hljs-variable language_">self</span>.FROM(*rest))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">SELECT</span>(<span class="hljs-params">self, table, columns, aliases=<span class="hljs-literal">None</span></span>):
         <span class="hljs-keyword">if</span> aliases <span class="hljs-keyword">is</span> <span class="hljs-literal">None</span>:
@@ -130,7 +135,7 @@ to Python.</p>
         <span class="hljs-keyword">return</span> table.<span class="hljs-built_in">filter</span>(pred)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">INSERT_INTO</span>(<span class="hljs-params">self, table_name, rows</span>):
-        table = self.tables[table_name]
+        table = <span class="hljs-variable language_">self</span>.tables[table_name]
         table.rows = (*table.rows, *rows)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">UPDATE</span>(<span class="hljs-params">self, table, <span class="hljs-built_in">set</span>, pred=<span class="hljs-keyword">lambda</span> _: <span class="hljs-literal">True</span></span>):
@@ -153,7 +158,7 @@ to Python.</p>
         <span class="hljs-keyword">return</span> Table(<span class="hljs-string">&quot;&quot;</span>, rows)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">INNER_JOIN</span>(<span class="hljs-params">self, a, b, pred</span>):
-        <span class="hljs-keyword">return</span> self.CROSS_JOIN(a, b).<span class="hljs-built_in">filter</span>(pred)
+        <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>.CROSS_JOIN(a, b).<span class="hljs-built_in">filter</span>(pred)
 
     JOIN = INNER_JOIN
 
@@ -176,7 +181,7 @@ to Python.</p>
         <span class="hljs-keyword">return</span> Table(<span class="hljs-string">&quot;&quot;</span>, rows)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">RIGHT_JOIN</span>(<span class="hljs-params">self, a, b, pred</span>):
-        <span class="hljs-keyword">return</span> self.LEFT_JOIN(b, a, pred)
+        <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>.LEFT_JOIN(b, a, pred)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">LIMIT</span>(<span class="hljs-params">self, table, limit</span>):
         <span class="hljs-keyword">return</span> Table(table.name, table.rows[:limit])
@@ -246,13 +251,13 @@ to Python.</p>
         <span class="hljs-keyword">return</span> Table(table.name, rows)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">COUNT</span>(<span class="hljs-params">self, table, col</span>):
-        <span class="hljs-keyword">return</span> self._aggregate(table, col, <span class="hljs-string">&quot;COUNT&quot;</span>, <span class="hljs-built_in">len</span>)
+        <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>._aggregate(table, col, <span class="hljs-string">&quot;COUNT&quot;</span>, <span class="hljs-built_in">len</span>)
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">MAX</span>(<span class="hljs-params">self, table, col</span>):
-        <span class="hljs-keyword">return</span> self._aggregate(table, col, <span class="hljs-string">&quot;MAX&quot;</span>, <span class="hljs-keyword">lambda</span> rows: <span class="hljs-built_in">max</span>(row[col] <span class="hljs-keyword">for</span> row <span class="hljs-keyword">in</span> rows))
+        <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>._aggregate(table, col, <span class="hljs-string">&quot;MAX&quot;</span>, <span class="hljs-keyword">lambda</span> rows: <span class="hljs-built_in">max</span>(row[col] <span class="hljs-keyword">for</span> row <span class="hljs-keyword">in</span> rows))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">SUM</span>(<span class="hljs-params">self, table, col</span>):
-        <span class="hljs-keyword">return</span> self._aggregate(table, col, <span class="hljs-string">&quot;SUM&quot;</span>, <span class="hljs-keyword">lambda</span> rows: <span class="hljs-built_in">sum</span>(row[col] <span class="hljs-keyword">for</span> row <span class="hljs-keyword">in</span> rows))
+        <span class="hljs-keyword">return</span> <span class="hljs-variable language_">self</span>._aggregate(table, col, <span class="hljs-string">&quot;SUM&quot;</span>, <span class="hljs-keyword">lambda</span> rows: <span class="hljs-built_in">sum</span>(row[col] <span class="hljs-keyword">for</span> row <span class="hljs-keyword">in</span> rows))
 
     <span class="hljs-keyword">def</span> <span class="hljs-title function_">__repr__</span>(<span class="hljs-params">self</span>):
         <span class="hljs-keyword">return</span> <span class="hljs-string">f&quot;Database(<span class="hljs-subst">{<span class="hljs-built_in">list</span>(self.tables.keys())!r}</span>)&quot;</span></pre></div></div>

--- a/docs/virtual-dom/index.html
+++ b/docs/virtual-dom/index.html
@@ -20,6 +20,11 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="../json-parser/index.html">
+                  ./json-parser/index.hs
+                </a>
+              
+                
                 <a class="source" href="../just-in-time/index.html">
                   ./just-in-time/index.py
                 </a>

--- a/json-parser/index.hs
+++ b/json-parser/index.hs
@@ -1,0 +1,244 @@
+-- # A JSON parser in Haskell
+--
+-- **License:** MIT
+--
+-- **Copyright:** (c) 2025 [Abhinav Sarkar](https://abhinavsarkar.net), Google
+--
+-- This is a [JSON](https://en.wikipedia.org/wiki/JSON) parser written from scratch in [Haskell](https://www.haskell.org/)
+-- in 183 lines. It complies with the JSON language specification set out in [IETF RFC 8259](https://tools.ietf.org/html/rfc8259),
+-- and passes the comprehensive [JSON test suite](https://github.com/nst/JSONTestSuite).
+--
+-- It is a recursive-descent parser, written in [Parser combinator](https://en.wikipedia.org/wiki/Parser_combinator)
+-- style.
+--
+-- Compile it with [GHC](https://www.haskell.org/ghc/) by running:
+--
+-- ```shell
+-- ghc --make *.hs -main-is JSONParser -o jsonparser
+-- ```
+--
+-- This parser has been extracted and simplified from Abhinav's blog post
+-- [JSON Parsing from Scratch in Haskell](https://abhinavsarkar.net/posts/json-parsing-from-scratch-in-haskell/).
+-- -----------------
+{-# LANGUAGE TupleSections, LambdaCase #-}
+module JSONParser where
+
+import Control.Applicative (Alternative(..), optional)
+import Control.Monad (replicateM)
+import Data.Bits (shiftL)
+import Data.Char (isDigit, isHexDigit, chr, ord, digitToInt)
+import Data.Functor (($>))
+import System.Exit (exitFailure)
+
+-- The data type for representing a JSON value in Haskell.
+data JValue =
+            -- Null, a null value.
+              JNull
+            -- Boolean, a boolean value.
+            | JBool Bool
+            -- String, a string value, a sequence of zero or more Unicode characters.
+            | JString String
+            -- Number, a numeric value representing integral and real numbers with support for scientific notation.
+            | JNumber { int :: Integer, frac :: [Int], exponent :: Integer }
+            -- Array, an ordered list of values.
+            | JArray [JValue]
+            -- Object, a collection of name-value pairs.
+            | JObject [(String, JValue)]
+            deriving (Eq)
+
+-- A generic parser type. It takes some input `i`, reads some part of it, and optionally parses it into some
+-- relevant data structure `o` and the rest of the input `i` to be potentially parsed later. It may fail as well.
+newtype Parser i o =
+  Parser { runParser :: i -> Maybe (i, o) }
+
+-- A `Parser` is a [`Functor`](https://hackage.haskell.org/package/base/docs/Data-Functor.html#t:Functor).
+-- This allows us to modify the result of a parser without changing the structure of the result (a parse success stays
+-- a success, and a failure stays a failure).
+instance Functor (Parser i) where
+  fmap f parser = Parser $ fmap (fmap f) . runParser parser
+
+-- A `Parser` is an [`Applicative`](https://hackage.haskell.org/package/base/docs/Control-Applicative.html#t:Applicative).
+-- This allows us to combine the results of two parsers that are independent of each-other.
+instance Applicative (Parser i) where
+  pure x    = Parser $ pure . (, x)
+  pf <*> po = Parser $ \input -> case runParser pf input of
+    Nothing        -> Nothing
+    Just (rest, f) -> fmap f <$> runParser po rest
+
+-- A `Parser` is an [`Alternative`](https://hackage.haskell.org/package/base/docs/Control-Applicative.html#t:Alternative).
+-- This allows us to fallback upon a second parser in case our first parser fails.
+instance Alternative (Parser i) where
+  empty = Parser $ const empty
+  p1 <|> p2 = Parser $ \input -> runParser p1 input <|> runParser p2 input
+
+-- A `Parser` is [`Monad`](https://hackage.haskell.org/package/base/docs/Control-Monad.html#t:Monad).
+-- This allows us to combine the results of two parsers sequentially, such that one parser is
+-- dependent on the result of other.
+instance Monad (Parser i) where
+  p >>= f = Parser $ \input -> case runParser p input of
+    Nothing        -> Nothing
+    Just (rest, o) -> runParser (f o) rest
+
+-- A parser that succeeds if the first element of its input list matches the given predicate.
+-- Returns the matching element on success.
+satisfy :: (a -> Bool) -> Parser [a] a
+satisfy predicate = Parser $ \case
+  (x:xs) | predicate x -> Just (xs, x)
+  _                    -> Nothing
+
+-- A parser that matches the first character of its input string with a given character.
+char :: Char -> Parser String Char
+char c = satisfy (== c)
+
+-- A parser that succeeds if the first character of its input string is a digit (0–9).
+digit :: Parser String Int
+digit = digitToInt <$> satisfy isDigit
+
+-- A parser that matches its input string with a given string.
+string :: String -> Parser String String
+string ""     = pure ""
+string (c:cs) = (:) <$> char c <*> string cs
+
+-- The parser for JSON `null` value that matches the string "null", and returns the `JNull` value on
+-- success.
+jNull :: Parser String JValue
+jNull = string "null" $> JNull
+
+-- The parser for JSON boolean values that matches the strings "true" or "false", and returns the
+-- corresponding `JBool` value on success.
+jBool :: Parser String JValue
+jBool =   string "true"  $> JBool True
+      <|> string "false" $> JBool False
+
+-- The parser for JSON characters that matches ASCII characters, as well as, escaped sequences
+-- for characters defined in the JSON spec, and Unicode characters with `\u` prefix and their hex-digit codes.
+jsonChar :: Parser String Char
+jsonChar =   string "\\\"" $> '"'
+         <|> string "\\\\" $> '\\'
+         <|> string "\\/"  $> '/'
+         <|> string "\\b"  $> '\b'
+         <|> string "\\f"  $> '\f'
+         <|> string "\\n"  $> '\n'
+         <|> string "\\r"  $> '\r'
+         <|> string "\\t"  $> '\t'
+         <|> unicodeChar
+         <|> satisfy (\c -> not (c == '\"' || c == '\\' || isControl c))
+  where
+    unicodeChar =
+      chr . fromIntegral . digitsToNumber 16 0
+        <$> (string "\\u" *> replicateM 4 hexDigit)
+
+    hexDigit = digitToInt <$> satisfy isHexDigit
+
+    isControl c = c `elem` ['\0' .. '\31']
+
+digitsToNumber :: Int -> Integer -> [Int] -> Integer
+digitsToNumber base =
+  foldl (\num d -> num * fromIntegral base + fromIntegral d)
+
+-- The parser for JSON strings that takes care of correctly parsing [UTF-16 surrogate pairs](https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF).
+jString :: Parser String JValue
+jString = JString <$> (char '"' *> jString')
+  where
+    jString' = do
+      optFirst <- optional jsonChar
+      case optFirst of
+        Nothing -> "" <$ char '"'
+        Just first | not (isSurrogate first) ->
+          (first:) <$> jString'
+        Just first -> do
+          second <- jsonChar
+          if isHighSurrogate first && isLowSurrogate second
+          then (combineSurrogates first second :) <$> jString'
+          else empty
+
+    isHighSurrogate a =
+      ord a >= highSurrogateLowerBound && ord a <= highSurrogateUpperBound
+    isLowSurrogate a  =
+      ord a >= lowSurrogateLowerBound && ord a <= lowSurrogateUpperBound
+    isSurrogate a     = isHighSurrogate a || isLowSurrogate a
+
+    combineSurrogates a b = chr $
+      ((ord a - highSurrogateLowerBound) `shiftL` 10)
+      + (ord b - lowSurrogateLowerBound) + 0x10000
+
+    highSurrogateLowerBound = 0xD800
+    highSurrogateUpperBound = 0xDBFF
+    lowSurrogateLowerBound  = 0xDC00
+    lowSurrogateUpperBound  = 0xDFFF
+
+-- The parser for JSON numbers in integer, decimal or scientific notation formats.
+jNumber :: Parser String JValue
+jNumber = jIntFracExp <|> jIntExp <|> jIntFrac <|> jInt
+  where
+    jInt = JNumber <$> jInt' <*> pure [] <*> pure 0
+    jIntExp = JNumber <$> jInt' <*> pure [] <*> jExp
+    jIntFrac = (\i f -> JNumber i f 0) <$> jInt' <*> jFrac
+    jIntFracExp = (\ ~(JNumber i f _) e -> JNumber i f e) <$> jIntFrac <*> jExp
+
+    jInt' = signInt <$> optional (char '-') <*> jUInt
+    jUInt =   (\d ds -> digitsToNumber 10 0 (d:ds)) <$> digit19 <*> digits
+          <|> fromIntegral <$> digit
+
+    jFrac = char '.' *> digits
+    jExp = (char 'e' <|> char 'E')
+      *> (signInt <$> optional (char '+' <|> char '-') <*> jUInt)
+
+    digit19 = digitToInt <$> satisfy (\x -> isDigit x && x /= '0')
+    digits = some digit
+
+    signInt (Just '-') i = negate i
+    signInt _          i = i
+
+surroundedBy ::
+  Parser String a -> Parser String b -> Parser String a
+surroundedBy p1 p2 = p2 *> p1 <* p2
+
+separatedBy :: Parser i v -> Parser i s -> Parser i [v]
+separatedBy v s =   (:) <$> v <*> many (s *> v)
+                <|> pure []
+
+spaces :: Parser String String
+spaces = many (char ' ' <|> char '\n' <|> char '\r' <|> char '\t')
+
+-- The parser for JSON arrays, containing zero or more items of any JSON types separated by commas.
+jArray :: Parser String JValue
+jArray = JArray <$>
+  (char '['
+   *> (jValue `separatedBy` char ',' `surroundedBy` spaces)
+   <* char ']')
+
+-- The parser for JSON objects, containing  zero or more key-value pairs separated by colon, where
+-- keys are JSON strings, and values are any JSON types.
+jObject :: Parser String JValue
+jObject = JObject <$>
+  (char '{' *> pair `separatedBy` char ',' `surroundedBy` spaces <* char '}')
+  where
+    pair = (\ ~(JString s) j -> (s, j))
+      <$> (jString `surroundedBy` spaces)
+      <*  char ':'
+      <*> jValue
+
+-- The parser for any JSON value, created by combining all the previous JSON parsers.
+jValue :: Parser String JValue
+jValue = jValue' `surroundedBy` spaces
+  where
+    jValue' =   jNull
+            <|> jBool
+            <|> jString
+            <|> jNumber
+            <|> jArray
+            <|> jObject
+
+-- `parseJSON` parses its input string as a JSON value, or fails on parsing errors.
+parseJSON :: String -> Maybe JValue
+parseJSON s = case runParser jValue s of
+  Just ("", j) -> Just j
+  _            -> Nothing
+
+-- `main` function reads text from standard input, and parses it as a JSON value.
+-- Prints a message indicating whether parsing succeeded or failed.
+main :: IO ()
+main = getContents >>= \input -> case parseJSON input of
+  Just _ -> putStrLn "Parse okay"
+  Nothing -> putStrLn "Parse failed" >> exitFailure

--- a/json-parser/index.hs
+++ b/json-parser/index.hs
@@ -5,7 +5,7 @@
 -- **Copyright:** (c) 2025 [Abhinav Sarkar](https://abhinavsarkar.net), Google
 --
 -- This is a [JSON](https://en.wikipedia.org/wiki/JSON) parser written from scratch in [Haskell](https://www.haskell.org/)
--- in 183 lines. It complies with the JSON language specification set out in [IETF RFC 8259](https://tools.ietf.org/html/rfc8259),
+-- in under 200 lines. It complies with the JSON language specification set out in [IETF RFC 8259](https://tools.ietf.org/html/rfc8259),
 -- and passes the comprehensive [JSON test suite](https://github.com/nst/JSONTestSuite).
 --
 -- It is a recursive-descent parser, written in [Parser combinator](https://en.wikipedia.org/wiki/Parser_combinator)

--- a/json-parser/index.hs
+++ b/json-parser/index.hs
@@ -20,8 +20,6 @@
 -- This parser has been extracted and simplified from Abhinav's blog post
 -- [JSON Parsing from Scratch in Haskell](https://abhinavsarkar.net/posts/json-parsing-from-scratch-in-haskell/).
 -- -----------------
-{-# LANGUAGE LambdaCase, TupleSections #-}
-
 module JSONParser where
 
 import Control.Applicative (Alternative (..), optional)
@@ -83,7 +81,7 @@ instance Monad (Parser i) where
 -- A parser that succeeds if the first element of its input list matches the given predicate.
 -- Returns the matching element on success.
 satisfy :: (a -> Bool) -> Parser [a] a
-satisfy predicate = Parser $ \case
+satisfy predicate = Parser $ \input -> case input of
   (x : xs) | predicate x -> Just (xs, x)
   _ -> Nothing
 
@@ -196,7 +194,7 @@ jNumber = jIntFracExp <|> jIntExp <|> jIntFrac <|> jInt
     signInt (Just '-') i = negate i
     signInt _ i = i
 
--- Some handy parser combinators
+-- Some handy parser combinators.
 surroundedBy :: Parser i a -> Parser i b -> Parser i a
 surroundedBy p1 p2 = p2 *> p1 <* p2
 
@@ -214,14 +212,14 @@ spaces = many (char ' ' <|> char '\n' <|> char '\r' <|> char '\t')
 -- The parser for JSON arrays, containing zero or more items of any JSON types separated by commas.
 jArray :: Parser String JValue
 jArray = fmap JArray
-  . between (char '[') (char ']')
+  $ between (char '[') (char ']')
   $ jValue `separatedBy` char ',' `surroundedBy` spaces
 
 -- The parser for JSON objects, containing  zero or more key-value pairs separated by colon, where
 -- keys are JSON strings, and values are any JSON types.
 jObject :: Parser String JValue
 jObject = fmap JObject
-  . between (char '{') ( char '}')
+  $ between (char '{') ( char '}')
   $ pair `separatedBy` char ',' `surroundedBy` spaces
   where
     pair =

--- a/json-parser/index.hs
+++ b/json-parser/index.hs
@@ -20,36 +20,37 @@
 -- This parser has been extracted and simplified from Abhinav's blog post
 -- [JSON Parsing from Scratch in Haskell](https://abhinavsarkar.net/posts/json-parsing-from-scratch-in-haskell/).
 -- -----------------
-{-# LANGUAGE TupleSections, LambdaCase #-}
+{-# LANGUAGE LambdaCase, TupleSections #-}
+
 module JSONParser where
 
-import Control.Applicative (Alternative(..), optional)
+import Control.Applicative (Alternative (..), optional)
 import Control.Monad (replicateM)
 import Data.Bits (shiftL)
-import Data.Char (isDigit, isHexDigit, chr, ord, digitToInt)
+import Data.Char (chr, digitToInt, isDigit, isHexDigit, ord)
 import Data.Functor (($>))
 import System.Exit (exitFailure)
 
 -- The data type for representing a JSON value in Haskell.
-data JValue =
-            -- Null, a null value.
-              JNull
-            -- Boolean, a boolean value.
-            | JBool Bool
-            -- String, a string value, a sequence of zero or more Unicode characters.
-            | JString String
-            -- Number, a numeric value representing integral and real numbers with support for scientific notation.
-            | JNumber { int :: Integer, frac :: [Int], exponent :: Integer }
-            -- Array, an ordered list of values.
-            | JArray [JValue]
-            -- Object, a collection of name-value pairs.
-            | JObject [(String, JValue)]
-            deriving (Eq)
+data JValue
+  =
+  -- Null, a null value.
+    JNull
+  -- Boolean, a boolean value.
+  | JBool Bool
+  -- String, a string value, a sequence of zero or more Unicode characters.
+  | JString String
+  -- Number, a numeric value representing integral and real numbers with support for scientific notation.
+  | JNumber {int :: Integer, frac :: [Int], exponent :: Integer}
+  -- Array, an ordered list of values.
+  | JArray [JValue]
+  -- Object, a collection of name-value pairs.
+  | JObject [(String, JValue)]
+  deriving (Eq)
 
 -- A generic parser type. It takes some input `i`, reads some part of it, and optionally parses it into some
 -- relevant data structure `o` and the rest of the input `i` to be potentially parsed later. It may fail as well.
-newtype Parser i o =
-  Parser { runParser :: i -> Maybe (i, o) }
+newtype Parser i o = Parser {runParser :: i -> Maybe (i, o)}
 
 -- A `Parser` is a [`Functor`](https://hackage.haskell.org/package/base/docs/Data-Functor.html#t:Functor).
 -- This allows us to modify the result of a parser without changing the structure of the result (a parse success stays
@@ -60,9 +61,9 @@ instance Functor (Parser i) where
 -- A `Parser` is an [`Applicative`](https://hackage.haskell.org/package/base/docs/Control-Applicative.html#t:Applicative).
 -- This allows us to combine the results of two parsers that are independent of each-other.
 instance Applicative (Parser i) where
-  pure x    = Parser $ pure . (, x)
+  pure x = Parser $ pure . (,x)
   pf <*> po = Parser $ \input -> case runParser pf input of
-    Nothing        -> Nothing
+    Nothing -> Nothing
     Just (rest, f) -> fmap f <$> runParser po rest
 
 -- A `Parser` is an [`Alternative`](https://hackage.haskell.org/package/base/docs/Control-Applicative.html#t:Alternative).
@@ -76,15 +77,15 @@ instance Alternative (Parser i) where
 -- dependent on the result of other.
 instance Monad (Parser i) where
   p >>= f = Parser $ \input -> case runParser p input of
-    Nothing        -> Nothing
+    Nothing -> Nothing
     Just (rest, o) -> runParser (f o) rest
 
 -- A parser that succeeds if the first element of its input list matches the given predicate.
 -- Returns the matching element on success.
 satisfy :: (a -> Bool) -> Parser [a] a
 satisfy predicate = Parser $ \case
-  (x:xs) | predicate x -> Just (xs, x)
-  _                    -> Nothing
+  (x : xs) | predicate x -> Just (xs, x)
+  _ -> Nothing
 
 -- A parser that matches the first character of its input string with a given character.
 char :: Char -> Parser String Char
@@ -96,8 +97,8 @@ digit = digitToInt <$> satisfy isDigit
 
 -- A parser that matches its input string with a given string.
 string :: String -> Parser String String
-string ""     = pure ""
-string (c:cs) = (:) <$> char c <*> string cs
+string "" = pure ""
+string (c : cs) = (:) <$> char c <*> string cs
 
 -- The parser for JSON `null` value that matches the string "null", and returns the `JNull` value on
 -- success.
@@ -107,22 +108,24 @@ jNull = string "null" $> JNull
 -- The parser for JSON boolean values that matches the strings "true" or "false", and returns the
 -- corresponding `JBool` value on success.
 jBool :: Parser String JValue
-jBool =   string "true"  $> JBool True
-      <|> string "false" $> JBool False
+jBool =
+  string "true" $> JBool True
+  <|> string "false" $> JBool False
 
 -- The parser for JSON characters that matches ASCII characters, as well as, escaped sequences
 -- for characters defined in the JSON spec, and Unicode characters with `\u` prefix and their hex-digit codes.
 jsonChar :: Parser String Char
-jsonChar =   string "\\\"" $> '"'
-         <|> string "\\\\" $> '\\'
-         <|> string "\\/"  $> '/'
-         <|> string "\\b"  $> '\b'
-         <|> string "\\f"  $> '\f'
-         <|> string "\\n"  $> '\n'
-         <|> string "\\r"  $> '\r'
-         <|> string "\\t"  $> '\t'
-         <|> unicodeChar
-         <|> satisfy (\c -> not (c == '\"' || c == '\\' || isControl c))
+jsonChar =
+  string "\\\"" $> '"'
+  <|> string "\\\\" $> '\\'
+  <|> string "\\/" $> '/'
+  <|> string "\\b" $> '\b'
+  <|> string "\\f" $> '\f'
+  <|> string "\\n" $> '\n'
+  <|> string "\\r" $> '\r'
+  <|> string "\\t" $> '\t'
+  <|> unicodeChar
+  <|> satisfy (\c -> not (c == '\"' || c == '\\' || isControl c))
   where
     unicodeChar =
       chr . fromIntegral . digitsToNumber 16 0
@@ -143,29 +146,30 @@ jString = JString <$> (char '"' *> jString')
     jString' = do
       optFirst <- optional jsonChar
       case optFirst of
-        Nothing -> "" <$ char '"'
-        Just first | not (isSurrogate first) ->
-          (first:) <$> jString'
+        Nothing -> char '"' $> ""
+        Just first | not (isSurrogate first) -> (first :) <$> jString'
         Just first -> do
           second <- jsonChar
           if isHighSurrogate first && isLowSurrogate second
-          then (combineSurrogates first second :) <$> jString'
-          else empty
+            then (combineSurrogates first second :) <$> jString'
+            else empty
 
     isHighSurrogate a =
       ord a >= highSurrogateLowerBound && ord a <= highSurrogateUpperBound
-    isLowSurrogate a  =
+    isLowSurrogate a =
       ord a >= lowSurrogateLowerBound && ord a <= lowSurrogateUpperBound
-    isSurrogate a     = isHighSurrogate a || isLowSurrogate a
+    isSurrogate a = isHighSurrogate a || isLowSurrogate a
 
-    combineSurrogates a b = chr $
-      ((ord a - highSurrogateLowerBound) `shiftL` 10)
-      + (ord b - lowSurrogateLowerBound) + 0x10000
+    combineSurrogates a b =
+      chr $
+        ((ord a - highSurrogateLowerBound) `shiftL` 10)
+          + (ord b - lowSurrogateLowerBound)
+          + 0x10000
 
     highSurrogateLowerBound = 0xD800
     highSurrogateUpperBound = 0xDBFF
-    lowSurrogateLowerBound  = 0xDC00
-    lowSurrogateUpperBound  = 0xDFFF
+    lowSurrogateLowerBound = 0xDC00
+    lowSurrogateUpperBound = 0xDFFF
 
 -- The parser for JSON numbers in integer, decimal or scientific notation formats.
 jNumber :: Parser String JValue
@@ -177,68 +181,77 @@ jNumber = jIntFracExp <|> jIntExp <|> jIntFrac <|> jInt
     jIntFracExp = (\ ~(JNumber i f _) e -> JNumber i f e) <$> jIntFrac <*> jExp
 
     jInt' = signInt <$> optional (char '-') <*> jUInt
-    jUInt =   (\d ds -> digitsToNumber 10 0 (d:ds)) <$> digit19 <*> digits
-          <|> fromIntegral <$> digit
+    jUInt =
+      (\d ds -> digitsToNumber 10 0 (d : ds)) <$> digit19 <*> digits
+      <|> fromIntegral <$> digit
 
     jFrac = char '.' *> digits
-    jExp = (char 'e' <|> char 'E')
-      *> (signInt <$> optional (char '+' <|> char '-') <*> jUInt)
+    jExp =
+      (char 'e' <|> char 'E')
+        *> (signInt <$> optional (char '+' <|> char '-') <*> jUInt)
 
     digit19 = digitToInt <$> satisfy (\x -> isDigit x && x /= '0')
     digits = some digit
 
     signInt (Just '-') i = negate i
-    signInt _          i = i
+    signInt _ i = i
 
-surroundedBy ::
-  Parser String a -> Parser String b -> Parser String a
+-- Some handy parser combinators
+surroundedBy :: Parser i a -> Parser i b -> Parser i a
 surroundedBy p1 p2 = p2 *> p1 <* p2
 
 separatedBy :: Parser i v -> Parser i s -> Parser i [v]
-separatedBy v s =   (:) <$> v <*> many (s *> v)
-                <|> pure []
+separatedBy v s =
+  (:) <$> v <*> many (s *> v)
+  <|> pure []
+
+between :: Parser i a -> Parser i a -> Parser i b -> Parser i b
+between pl pr p = pl *> p <* pr
 
 spaces :: Parser String String
 spaces = many (char ' ' <|> char '\n' <|> char '\r' <|> char '\t')
 
 -- The parser for JSON arrays, containing zero or more items of any JSON types separated by commas.
 jArray :: Parser String JValue
-jArray = JArray <$>
-  (char '['
-   *> (jValue `separatedBy` char ',' `surroundedBy` spaces)
-   <* char ']')
+jArray = fmap JArray
+  . between (char '[') (char ']')
+  $ jValue `separatedBy` char ',' `surroundedBy` spaces
 
 -- The parser for JSON objects, containing  zero or more key-value pairs separated by colon, where
 -- keys are JSON strings, and values are any JSON types.
 jObject :: Parser String JValue
-jObject = JObject <$>
-  (char '{' *> pair `separatedBy` char ',' `surroundedBy` spaces <* char '}')
+jObject = fmap JObject
+  . between (char '{') ( char '}')
+  $ pair `separatedBy` char ',' `surroundedBy` spaces
   where
-    pair = (\ ~(JString s) j -> (s, j))
-      <$> (jString `surroundedBy` spaces)
-      <*  char ':'
-      <*> jValue
+    pair =
+      (\ ~(JString s) j -> (s, j))
+        <$> (jString `surroundedBy` spaces)
+        <* char ':'
+        <*> jValue
 
 -- The parser for any JSON value, created by combining all the previous JSON parsers.
 jValue :: Parser String JValue
 jValue = jValue' `surroundedBy` spaces
   where
-    jValue' =   jNull
-            <|> jBool
-            <|> jString
-            <|> jNumber
-            <|> jArray
-            <|> jObject
+    jValue' =
+      jNull
+        <|> jBool
+        <|> jString
+        <|> jNumber
+        <|> jArray
+        <|> jObject
 
 -- `parseJSON` parses its input string as a JSON value, or fails on parsing errors.
 parseJSON :: String -> Maybe JValue
 parseJSON s = case runParser jValue s of
   Just ("", j) -> Just j
-  _            -> Nothing
+  _ -> Nothing
 
 -- `main` function reads text from standard input, and parses it as a JSON value.
 -- Prints a message indicating whether parsing succeeded or failed.
 main :: IO ()
-main = getContents >>= \input -> case parseJSON input of
-  Just _ -> putStrLn "Parse okay"
-  Nothing -> putStrLn "Parse failed" >> exitFailure
+main =
+  getContents >>= \input -> case parseJSON input of
+    Just _ -> putStrLn "Parse okay"
+    Nothing -> putStrLn "Parse failed" >> exitFailure

--- a/package-lock.json
+++ b/package-lock.json
@@ -857,10 +857,11 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
-      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
     "remark-cli": "^12.0.1",
     "remark-html": "^16.0.1"
   },
+  "overrides": {
+    "highlight.js": "^11.8.0"
+  },
   "scripts": {
-    "docco": "find . \\( -name '*.js' -o -name '*.py' \\) ! -path './node_modules/*' ! -path './scripts/*' | xargs docco",
+    "docco": "find . \\( -name '*.js' -o -name '*.py' -o -name '*.hs' \\) ! -path './node_modules/*' ! -path './scripts/*' | xargs docco",
     "gen-site": "npm run docco && node _scripts/generateIndex.mjs > docs/index.html"
   }
 }


### PR DESCRIPTION
This is a JSON parser written from scratch in Haskell in 200-ish lines. It complies with the JSON language specification set out in [IETF RFC 8259](https://tools.ietf.org/html/rfc8259), and passes the comprehensive [JSON test suite](https://github.com/nst/JSONTestSuite).

I also updated the highlight.js dependency to the latest version to get correct highlighting for Haskell code, and changed the `gen-site` command to accept Haskell files.